### PR TITLE
Unambigious display strings

### DIFF
--- a/backend/model/archival_object_ext.rb
+++ b/backend/model/archival_object_ext.rb
@@ -1,0 +1,1 @@
+ArchivalObject.include(ReindexTopContainers)

--- a/backend/model/container_profile.rb
+++ b/backend/model/container_profile.rb
@@ -13,11 +13,15 @@ class ContainerProfile < Sequel::Model(:container_profile)
                       :is_array => false)
 
 
+  def display_string
+    name
+  end
+
   def self.sequel_to_jsonmodel(objs, opts = {})
     jsons = super
 
     jsons.zip(objs).each do |json, obj|
-      json['display_string'] = obj.name
+      json['display_string'] = obj.display_string
     end
 
     jsons

--- a/backend/model/mixins/reindex_top_containers.rb
+++ b/backend/model/mixins/reindex_top_containers.rb
@@ -1,0 +1,31 @@
+module ReindexTopContainers
+
+  def reindex_top_containers
+    # Find any relationships between a top container and any instance within the current tree.
+    tree_object_graph = self.class.root_model[self.root_record_id].object_graph
+    top_container_link_rlshp = SubContainer.find_relationship(:top_container_link)
+    relationship_ids = tree_object_graph.ids_for(top_container_link_rlshp)
+
+    # Update the mtimes of each top containers
+    DB.open do |db|
+      top_container_ids = db[:top_container_link_rlshp].filter(:id => relationship_ids).select(:top_container_id)
+      TopContainer.filter(:id => top_container_ids).update(:system_mtime => Time.now)
+    end
+  end
+
+
+  def update_position_only(*)
+    super
+    reindex_top_containers
+  end
+
+
+  def update_from_json(json, opts = {}, apply_nested_records = true)
+    result = super
+
+    reindex_top_containers
+
+    result
+  end
+
+end

--- a/backend/model/mixins/reindex_top_containers.rb
+++ b/backend/model/mixins/reindex_top_containers.rb
@@ -20,6 +20,12 @@ module ReindexTopContainers
   end
 
 
+  def delete
+    reindex_top_containers
+    super
+  end
+
+
   def update_from_json(json, opts = {}, apply_nested_records = true)
     result = super
 

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -83,8 +83,19 @@ class TopContainer < Sequel::Model(:top_container)
     end
   end
 
+
+  def container_profile_display_string
+    container_profile = related_records(:top_container_profile)
+    if container_profile
+      container_profile.display_string
+    else
+      ""
+    end
+  end
+
+
   def display_string
-    "#{self.indicator} #{self.format_barcode} #{self.series_display_string}".strip
+    "#{self.container_profile_display_string} #{self.indicator} #{self.format_barcode} #{self.series_display_string}".strip
   end
 
 

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -36,6 +36,18 @@ class TopContainer < Sequel::Model(:top_container)
   end
 
 
+  # For Archival Objects, the series is the topmost record in the tree.
+  def tree_top(obj)
+    return obj if !obj.is_a?(TreeNodes)
+
+    while obj.parent_id
+      obj = obj.class[obj.parent_id]
+    end
+
+    obj
+  end
+
+
   def series
     # Take the first linked subcontainer
     subcontainer = related_records(:top_container_link).first
@@ -53,7 +65,7 @@ class TopContainer < Sequel::Model(:top_container)
       key = association[:key]
 
       if instance[key]
-        return model[instance[key]]
+        return tree_top(model[instance[key]])
       end
     end
 
@@ -62,7 +74,13 @@ class TopContainer < Sequel::Model(:top_container)
 
 
   def series_display_string
-    ""
+    series_record = series
+
+    if series_record
+      ": #{series_record.display_string}"
+    else
+      ""
+    end
   end
 
   def display_string

--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -175,5 +175,15 @@ describe 'Yale Container model' do
   end
 
 
-  it "It incorporates container profile names into display strings"
+  it "incorporates container profile names into display strings" do
+    test_container_profile = create(:json_container_profile, :name => "Cardboard box")
+
+    container_with_profile = create(:json_top_container,
+                                    'barcode' => '123',
+                                    'indicator' => '1',
+                                    'container_profile' => {'ref' => test_container_profile.uri})
+
+    TopContainer[container_with_profile.id].display_string.should eq("Cardboard box 1 [123]")
+  end
+
 end

--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -173,4 +173,7 @@ describe 'Yale Container model' do
 
     end
   end
+
+
+  it "It incorporates container profile names into display strings"
 end

--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -59,13 +59,6 @@ describe 'Yale Container model' do
   end
 
 
-  it "displays barcodes in the display string" do
-    obj = create(:json_top_container, :indicator => "1", :barcode => "1234")
-
-    TopContainer.to_jsonmodel(obj.id).display_string.should eq("1 [1234]")
-  end
-
-
   it "can be linked to a container profile" do
     test_container_profile = create(:json_container_profile)
 
@@ -91,6 +84,7 @@ describe 'Yale Container model' do
                          })]
                        })
 
+
     expect { TopContainer[box.id].delete }.to raise_error(ConflictException)
   end
 
@@ -98,6 +92,40 @@ describe 'Yale Container model' do
     box = create(:json_top_container)
 
     expect { TopContainer[box.id].delete }.to_not raise_error
+  end
+
+
+  describe "display strings" do
+
+    let (:box) { create(:json_top_container, :indicator => "1", :barcode => "123") }
+    let (:top_container) { TopContainer[box.id] }
+
+    xit "can link a Top Container to a series and get back a display string containing the series name"
+
+    it "can show a display string for a top container that isn't linked to anything" do
+      top_container.display_string.should eq("1 [123]")
+    end
+
+
+    it "can find an accession linked to a given top container" do
+      accession = create_accession({
+                                     "instances" => [build(:json_instance, {
+                                                             "instance_type" => "accession",
+                                                             "sub_container" => build(:json_sub_container, {
+                                                                                        "top_container" => {
+                                                                                          "ref" => box.uri
+                                                                                        }
+                                                                                      })
+                                                           })]
+                                   })
+
+      series = top_container.series
+      series.should be_instance_of(Accession)
+      series.id.should eq(accession.id)
+    end
+
+    xit "can find the topmost archival object linked to a given top container" do
+    end
   end
 
 end

--- a/frontend/views/top_containers/_new.html.erb
+++ b/frontend/views/top_containers/_new.html.erb
@@ -5,4 +5,4 @@
   <% end %>
 <% end %>
 
-<script src="<%= "#{AppConfig[:frontend_prefix]}assets/yale_containers.new.js" %>"></script>
+<script src="<%= "#{AppConfig[:frontend_prefix]}assets/top_containers.crud.js" %>"></script>

--- a/frontend/views/top_containers/edit.html.erb
+++ b/frontend/views/top_containers/edit.html.erb
@@ -26,4 +26,4 @@
 <% end %>
 
 <script src="<%= "#{AppConfig[:frontend_prefix]}assets/subrecord.crud.js" %>"></script>
-<script src="<%= "#{AppConfig[:frontend_prefix]}assets/yale_containers.new.js" %>"></script>
+<script src="<%= "#{AppConfig[:frontend_prefix]}assets/top_containers.crud.js" %>"></script>


### PR DESCRIPTION
When displaying labels for top containers, show some additional pieces of information:

  * The container profile
  * The series that the top container is connected to

Lots of fiddling to make sure it behaves properly even as archival objects are edited, moved around within trees, merged with other resources, transferred between repositories, etc. etc.