### PR TITLE
[Delivers #82734844] Index permuations of a top container's linked record's identifier 

### DIFF
--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -122,12 +122,14 @@ class TopContainer < Sequel::Model(:top_container)
       if series = obj.series
         json['series'] = {
           'ref' => series.uri,
+          'identifier' => series.component_id,
           'display_string' => find_title_for(series)
         }
       end
       if collection = obj.collection
         json['collection'] = {
           'ref' => collection.uri,
+          'identifier' => Identifiers.format(Identifiers.parse(collection.identifier)),
           'display_string' => find_title_for(collection)
         }
       end
@@ -195,6 +197,8 @@ class TopContainer < Sequel::Model(:top_container)
       set_filter_terms(params[:filter_term]).
       set_facets(params[:facet])
 
+
+    query.add_solr_param(:qf, "series_identifier_u_stext collection_identifier_u_stext")
 
     url = query.to_solr_url
     req = Net::HTTP::Get.new(url.request_uri)

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -11,10 +11,12 @@ class CommonIndexer
         if record['record']['series']
           doc['series_uri_u_sstr'] = record['record']['series']['ref']
           doc['series_title_u_sstr'] = record['record']['series']['display_string']
+          doc['series_identifier_u_stext'] = CommonIndexer.generate_permuations_for_identifier(record['record']['series']['identifier'])
         end
         if record['record']['collection']
           doc['collection_uri_u_sstr'] = record['record']['collection']['ref']
           doc['collection_display_string_u_sstr'] = record['record']['collection']['display_string']
+          doc['collection_identifier_u_stext'] = CommonIndexer.generate_permuations_for_identifier(record['record']['collection']['identifier'])
         end
         if record['record']['container_profile']
           doc['container_profile_uri_u_sstr'] = record['record']['container_profile']['ref']
@@ -47,6 +49,18 @@ class CommonIndexer
         doc["container_profile_dimension_units_u_sstr"] = record['record']['dimension_units']
       end
     }
+  end
+
+
+  def self.generate_permuations_for_identifier(identifer)
+    return [] if identifer.nil?
+
+    [
+      identifer,
+      identifer.gsub(/[[:punct:]]+/, " "),
+      identifer.gsub(/[[:punct:] ]+/, ""),
+      identifer.scan(/([0-9]+|[^0-9]+)/).flatten(1).join(" ")
+    ].uniq
   end
 
 end

--- a/schemas/top_container.rb
+++ b/schemas/top_container.rb
@@ -46,6 +46,7 @@
             "type" => "JSONModel(:archival_object) uri",
           },
           "display_string" => {"type" => "string"},
+          "identifier" => {"type" => "string"},
           "_resolved" => {
             "type" => "object",
             "readonly" => "true"
@@ -65,6 +66,7 @@
             ]
           },
           "display_string" => {"type" => "string"},
+          "identifier" => {"type" => "string"},
           "_resolved" => {
             "type" => "object",
             "readonly" => "true"


### PR DESCRIPTION
...and allow these fields to be searched via a keyword search

Fields that can now be searched for via the text search include:
- Identifier of linked series
- top container display string
- accession identifiers
- resource identifiers
- location barcode

By also indexing permutations of the identifier, we also cover this requirement "We want to be able to search by collection ID and collection title. Whitespace and punctuation on collection ID should be trivial (MS.1642 and MS1642 should result in same results)".