### PR TITLE
[Delivers #82734794] Add new bulk selection table columns

### DIFF
--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -94,12 +94,13 @@ class TopContainer < Sequel::Model(:top_container)
   end
 
 
-  def series_label
-    series_record = series
+  def level_display_string
+    series.other_level || I18n.t("enumerations.archival_record_level.#{series.level}", series.level)
+  end
 
+  def series_label
     if series
-      level = series.other_level || I18n.t("enumerations.archival_record_level.#{series.level}", series.level)
-      "#{level} #{series.component_id}"
+      "#{level_display_string} #{series.component_id}"
     end
   end
 
@@ -119,7 +120,8 @@ class TopContainer < Sequel::Model(:top_container)
         json['series'] = {
           'ref' => series.uri,
           'identifier' => series.component_id,
-          'display_string' => find_title_for(series)
+          'display_string' => find_title_for(series),
+          'level_display_string' => obj.level_display_string
         }
       end
       if collection = obj.collection

--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -162,10 +162,19 @@ describe 'Yale Container model' do
       end
 
       it "includes the series in its JSON output" do
-        (resource, grandparent, parent, child) = create_tree(box)
+        (resource, grandparent, parent, child) = create_tree(box,
+                                                             :grandparent_properties => {
+                                                              'component_id' => 'GP1',
+                                                              'level' => 'series'
+                                                             })
 
         json = TopContainer.to_jsonmodel(top_container.id)
-        json.series.should eq({'ref' => grandparent.uri, 'display_string' => grandparent.display_string})
+        json.series.should eq({
+          'ref' => grandparent.uri,
+          'identifier' => grandparent.component_id,
+          'display_string' => grandparent.display_string,
+          'level_display_string' => 'Series'
+        })
       end
 
       it "can get the collection linked to a given top container" do

--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -5,6 +5,7 @@ function BulkContainerSearch($search_form, $results_container, $toolbar) {
 
   this.setup_form();
   this.setup_results_list();
+  this.setup_bulk_action_test();
 }
 
 BulkContainerSearch.prototype.setup_form = function() {
@@ -29,10 +30,12 @@ BulkContainerSearch.prototype.perform_search = function(data) {
     success: function(html) {
       self.$results_container.html(html);
       self.setup_table_sorter();
+      self.update_button_state();
     },
     error: function(jqXHR, textStatus, errorThrown) {
       var html = AS.renderTemplate("template_bulk_operation_error_message", {message: jqXHR.responseText})
       self.$results_container.html(html);
+      self.update_button_state();
     }
   });
 };
@@ -86,6 +89,28 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
     sortList: [[1,0],[3,0],[4,0],[6,0]]
   };
   this.$results_container.find("table").tablesorter(tablesorter_opts);
+};
+
+BulkContainerSearch.prototype.get_selection = function() {
+  var self = this;
+  var results = [];
+
+  self.$results_container.find("tbody :checkbox:checked").each(function(i, checkbox) {
+    results.push([checkbox.value, $(checkbox).data("display-string")]);
+  });
+
+  return results;
+};
+
+BulkContainerSearch.prototype.setup_bulk_action_test = function() {
+  var self = this;
+  var $link = $("#bulkActionTestSelection", self.$toolbar);
+
+  $link.on("click", function() {
+    AS.openQuickModal("Test Selection", AS.renderTemplate("bulk_action_test_selection", {
+      selection: self.get_selection()
+    }))
+  });
 };
 
 

--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -83,7 +83,7 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
       0: { sorter: false}
     },
     // default sort: Collection, Series, Indicator
-    sortList: [[1,0],[2,0],[4,0]]
+    sortList: [[1,0],[3,0],[4,0],[6,0]]
   };
   this.$results_container.find("table").tablesorter(tablesorter_opts);
 };

--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -76,6 +76,8 @@ BulkContainerSearch.prototype.update_button_state = function() {
 
 BulkContainerSearch.prototype.setup_table_sorter = function() {
   var tablesorter_opts = {
+    // only sort on the second row of header columns
+    selectorHeaders: "thead tr.sortable-columns th",
     // disable sort on the checkbox column
     headers: {
       0: { sorter: false}

--- a/frontend/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
@@ -1,0 +1,7 @@
+<div id="bulk_action_test_selection"><!--
+  <ul>
+  {for container in selection}
+    <li><strong>${container[1]}</strong>&nbsp;&nbsp;&nbsp;${container[0]}</li>
+  {/for}
+  </ul>
+--></div>

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -12,6 +12,8 @@
   <p>Matching results: <strong><%= num_found %></strong></p>
 <% end %>
 
+<p><small>Click a column to set the sort ordering.  Hold shift to sort by multiple columns.</small></p>
+
 <table class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results">
   <thead>
     <tr>
@@ -43,14 +45,14 @@
       <% container_json = ASUtils.json_parse(doc['json']) %>
       <tr>
         <td><%= check_box_tag "uri", container_json['uri'] %></td>
-        <td><%= "ID" %></td>
-        <td><%= "Title" %></td>
-        <td><%= "Level" %></td>
-        <td><%= "ID" %></td>
-        <td><%= (doc['container_profile_display_string_u_sstr'] || [""]).first %></td>
+        <td><%= Array(doc['collection_identifier_u_stext']).first %></td>
+        <td><%= Array(doc['collection_display_string_u_sstr']).first %></td>
+        <td><%= Array(doc['series_level_u_sstr']).first %></td>
+        <td><%= Array(doc['series_identifier_u_stext']).first %></td>
+        <td><%= Array(doc['container_profile_display_string_u_sstr']).first %></td>
         <td><%= container_json['indicator'] %></td>
         <td><%= container_json['barcode'] %></td>
-        <td><%= (doc['location_display_string_u_sstr'] || [""]).first %></td>
+        <td><%= Array(doc['location_display_string_u_sstr']).first %></td>
         <td><%= container_json['ils_holding_id'] %></td>
         <td><%= container_json['ils_item_id'] %></td>
         <td><%= I18n.t("boolean.#{container_json['restricted']}") %></td>

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -44,7 +44,7 @@
     <% top_containers.each do |doc| %>
       <% container_json = ASUtils.json_parse(doc['json']) %>
       <tr>
-        <td><%= check_box_tag "uri", container_json['uri'] %></td>
+        <td><%= check_box_tag "uri", container_json['uri'], false, "data-display-string" => doc['title'] %></td>
         <td><%= Array(doc['collection_identifier_u_stext']).first %></td>
         <td><%= Array(doc['collection_display_string_u_sstr']).first %></td>
         <td><%= Array(doc['series_level_u_sstr']).first %></td>

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -15,9 +15,18 @@
 <table class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results">
   <thead>
     <tr>
+      <th></th>
+      <th colspan="2">Collection/Accession</th>
+      <th colspan="2">Series</th>
+      <th colspan="8">Top Container</th>
+      <th></th>
+    </tr>
+    <tr class="sortable-columns">
       <th><%= check_box_tag "select_all" %></th>
-      <th>Collection/Accession</th>
-      <th>Series</th>
+      <th>ID</th>
+      <th>Title</th>
+      <th>Level</th>
+      <th>ID</th>
       <th>Container Profile</th>
       <th>Indicator</th>
       <th>Barcode</th>
@@ -34,8 +43,10 @@
       <% container_json = ASUtils.json_parse(doc['json']) %>
       <tr>
         <td><%= check_box_tag "uri", container_json['uri'] %></td>
-        <td><%= (doc['collection_display_string_u_sstr'] || [""]).first %></td>
-        <td><%= (doc['series_title_u_sstr'] || [""]).first %></td>
+        <td><%= "ID" %></td>
+        <td><%= "Title" %></td>
+        <td><%= "Level" %></td>
+        <td><%= "ID" %></td>
         <td><%= (doc['container_profile_display_string_u_sstr'] || [""]).first %></td>
         <td><%= container_json['indicator'] %></td>
         <td><%= container_json['barcode'] %></td>

--- a/frontend/views/top_containers/bulk_operations/_toolbar.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_toolbar.html.erb
@@ -6,7 +6,7 @@
         <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
-        <li>TODO</li>
+        <li><a id="bulkActionTestSelection" href="javascript:void(0)">Test Selection</a></li>
       </ul>
     </div>
     <%= button_delete_action(url_for(:controller => :top_containers, :action => :batch_delete), {

--- a/frontend/views/top_containers/index.html.erb
+++ b/frontend/views/top_containers/index.html.erb
@@ -66,5 +66,7 @@
   </div>
 --></div>
 
+<%= render_aspace_partial :partial => "top_containers/bulk_operations/bulk_action_templates" %>
+
 <script src="<%= "#{AppConfig[:frontend_prefix]}assets/jquery.tablesorter.min.js" %>"></script>
 <script src="<%= "#{AppConfig[:frontend_prefix]}assets/top_containers.bulk.js" %>"></script>

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -11,12 +11,13 @@ class CommonIndexer
         if record['record']['series']
           doc['series_uri_u_sstr'] = record['record']['series']['ref']
           doc['series_title_u_sstr'] = record['record']['series']['display_string']
-          doc['series_identifier_u_stext'] = CommonIndexer.generate_permuations_for_identifier(record['record']['series']['identifier'])
+          doc['series_level_u_sstr'] = record['record']['series']['level_display_string']
+          doc['series_identifier_u_stext'] = CommonIndexer.generate_permutations_for_identifier(record['record']['series']['identifier'])
         end
         if record['record']['collection']
           doc['collection_uri_u_sstr'] = record['record']['collection']['ref']
           doc['collection_display_string_u_sstr'] = record['record']['collection']['display_string']
-          doc['collection_identifier_u_stext'] = CommonIndexer.generate_permuations_for_identifier(record['record']['collection']['identifier'])
+          doc['collection_identifier_u_stext'] = CommonIndexer.generate_permutations_for_identifier(record['record']['collection']['identifier'])
         end
         if record['record']['container_profile']
           doc['container_profile_uri_u_sstr'] = record['record']['container_profile']['ref']
@@ -52,7 +53,7 @@ class CommonIndexer
   end
 
 
-  def self.generate_permuations_for_identifier(identifer)
+  def self.generate_permutations_for_identifier(identifer)
     return [] if identifer.nil?
 
     [

--- a/schemas/top_container.rb
+++ b/schemas/top_container.rb
@@ -50,6 +50,7 @@
           },
           "display_string" => {"type" => "string"},
           "identifier" => {"type" => "string"},
+          "level_display_string" => {"type" => "string"},
           "_resolved" => {
             "type" => "object",
             "readonly" => "true"


### PR DESCRIPTION
Format the bulk selection table based on the specified table columns: 

* Resource Identifier
* Resource Title
* The Component Unique Identifier for the highest ancestor component (this is because boxes often start over from 1 for each series -- we need the component identifier, like “Series 1” or “Accession 2015-A-005” in order to know which Box 1 we’re working with)
* Container profile name
* Container Number
* Barcode
* Location string
* Voyager Holdings Record Identifier value
* Restriction information
* Value of whether this container has been exported to Voyager (translate timestamp = present to yes)