### PR TITLE
enforce barcode length limits as specified in config [delivers 82360390]

### DIFF
--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -17,7 +17,7 @@ class TopContainer < Sequel::Model(:top_container)
     map_validation_to_json_property([:repo_id, :barcode], :barcode)
 
     if cfg = AppConfig[:yale_containers_barcode_length]
-      repo_key = "repository_#{self.class.active_repository}".intern
+      repo_key = Repository[self.class.active_repository].repo_code
       min = 0
       max = 255
       [:system_default, repo_key].each do |key|

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -16,6 +16,21 @@ class TopContainer < Sequel::Model(:top_container)
                      :message => "A barcode must be unique within a repository")
     map_validation_to_json_property([:repo_id, :barcode], :barcode)
 
+    if cfg = AppConfig[:yale_containers_barcode_length]
+      repo_key = "repository_#{self.class.active_repository}".intern
+      min = 0
+      max = 255
+      [:system_default, repo_key].each do |key|
+        if cfg.has_key?(key)
+          min = cfg[key][:min] if cfg[key].has_key?(:min)
+          max = cfg[key][:max] if cfg[key].has_key?(:max)
+        end
+      end
+      if (!self[:barcode].nil? && (self[:barcode].length < min || self[:barcode].length > max))
+        errors.add(:barcode, "Length must be within the range set in configuration")
+      end
+    end
+
     super
   end
 

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -16,19 +16,10 @@ class TopContainer < Sequel::Model(:top_container)
                      :message => "A barcode must be unique within a repository")
     map_validation_to_json_property([:repo_id, :barcode], :barcode)
 
-    if cfg = AppConfig[:yale_containers_barcode_length]
-      repo_key = Repository[self.class.active_repository].repo_code
-      min = 0
-      max = 255
-      [:system_default, repo_key].each do |key|
-        if cfg.has_key?(key)
-          min = cfg[key][:min] if cfg[key].has_key?(:min)
-          max = cfg[key][:max] if cfg[key].has_key?(:max)
-        end
-      end
-      if (!self[:barcode].nil? && (self[:barcode].length < min || self[:barcode].length > max))
-        errors.add(:barcode, "Length must be within the range set in configuration")
-      end
+    check = BarcodeCheck.new(Repository[self.class.active_repository].repo_code)
+
+    if !check.valid?(self[:barcode])
+      errors.add(:barcode, "Length must be within the range set in configuration")
     end
 
     super

--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -113,21 +113,14 @@ class TopContainersController < ApplicationController
   end
 
 
+  include ApplicationHelper
+
   helper_method :barcode_length_range
   def barcode_length_range
-    min = 0
-    max = 255
-    if cfg = AppConfig[:yale_containers_barcode_length]
-      repo_key = JSONModel(:repository).find(session['repo_id']).repo_code
-      [:system_default, repo_key].each do |key|
-        if cfg.has_key?(key)
-          min = cfg[key][:min] if cfg[key].has_key?(:min)
-          max = cfg[key][:max] if cfg[key].has_key?(:max)
-        end
-      end
-    end
-    "#{min}-#{max}"
+    check = BarcodeCheck.new(current_repo[:repo_code])
+    "#{check.min}-#{check.max}"
   end
+
 
   def search_filter_for(uri)
     return {} if uri.blank?

--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -118,7 +118,7 @@ class TopContainersController < ApplicationController
     min = 0
     max = 255
     if cfg = AppConfig[:yale_containers_barcode_length]
-      repo_key = "repository_#{session['repo_id']}".intern
+      repo_key = JSONModel(:repository).find(session['repo_id']).repo_code
       [:system_default, repo_key].each do |key|
         if cfg.has_key?(key)
           min = cfg[key][:min] if cfg[key].has_key?(:min)

--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -113,6 +113,22 @@ class TopContainersController < ApplicationController
   end
 
 
+  helper_method :barcode_length_range
+  def barcode_length_range
+    min = 0
+    max = 255
+    if cfg = AppConfig[:yale_containers_barcode_length]
+      repo_key = "repository_#{session['repo_id']}".intern
+      [:system_default, repo_key].each do |key|
+        if cfg.has_key?(key)
+          min = cfg[key][:min] if cfg[key].has_key?(:min)
+          max = cfg[key][:max] if cfg[key].has_key?(:max)
+        end
+      end
+    end
+    "#{min}-#{max}"
+  end
+
   def search_filter_for(uri)
     return {} if uri.blank?
 

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -36,6 +36,9 @@ en:
     yale_container_3_type: Grandchild Container Type
     yale_container_3_indicator: Grandchild Container Indicator
 
+    barcode_length_for_this_repository: "Barcode length for this repository:"
+    characters: characters
+
     _singular: Top Container
     _plural: Top Containers
 
@@ -82,6 +85,7 @@ en:
     a_barcode_must_be_unique_within_a_repository: A barcode must be unique within a repository
     container_profile_name_not_unique: Container Profile name must be unique
     must_be_a_number_with_no_more_than_2_decimal_places: Must be a number with no more than 2 decimal places
+    length_must_be_within_the_range_set_in_configuration: Length must be within the range set in configuration
 
   search_results:
     filter:

--- a/frontend/views/top_containers/_form.html.erb
+++ b/frontend/views/top_containers/_form.html.erb
@@ -8,9 +8,12 @@
   <%= form.label_and_textfield("indicator") %>
 
   <%= form.label_and_textfield("barcode") %>
-  <div class='controls label-only'>
-    <%= I18n.t("top_container.barcode_length_for_this_repository") %> <%= barcode_length_range %> <%= I18n.t("top_container.characters") %>
+  <div class="controls label-only">
+      <span class='help-inline'>
+          <%= I18n.t("top_container.barcode_length_for_this_repository") %> <%= barcode_length_range %> <%= I18n.t("top_container.characters") %>
+      </span>
   </div>
+
   <%= form.label_and_textfield("ils_holding_id") %>
   <%= form.label_and_textfield("ils_item_id") %>
   <%= form.label_and_readonly("exported_to_ils", I18n.t("top_container.not_exported")) %>

--- a/frontend/views/top_containers/_form.html.erb
+++ b/frontend/views/top_containers/_form.html.erb
@@ -8,6 +8,9 @@
   <%= form.label_and_textfield("indicator") %>
 
   <%= form.label_and_textfield("barcode") %>
+  <div class='controls label-only'>
+    <%= I18n.t("top_container.barcode_length_for_this_repository") %> <%= barcode_length_range %> <%= I18n.t("top_container.characters") %>
+  </div>
   <%= form.label_and_textfield("ils_holding_id") %>
   <%= form.label_and_textfield("ils_item_id") %>
   <%= form.label_and_readonly("exported_to_ils", I18n.t("top_container.not_exported")) %>

--- a/lib/barcode_check.rb
+++ b/lib/barcode_check.rb
@@ -1,0 +1,27 @@
+class BarcodeCheck
+
+  attr_reader :min, :max
+
+  def initialize(repo_code)
+    @min = 0
+    @max = 255
+
+    return if !AppConfig.has_key?(:yale_containers_barcode_length)
+
+    cfg = AppConfig[:yale_containers_barcode_length]
+
+    repo_key = "repository_#{repo_code}".intern
+    [:system_default, repo_key].each do |key|
+      if cfg.has_key?(key)
+        @min = cfg[key][:min].to_i if cfg[key].has_key?(:min)
+        @max = cfg[key][:max].to_i if cfg[key].has_key?(:max)
+      end
+    end
+  end
+
+
+  def valid?(barcode)
+    barcode && (min..max).cover?(barcode.length)
+  end
+
+end

--- a/yale_container_init.rb
+++ b/yale_container_init.rb
@@ -1,3 +1,6 @@
+require_relative 'lib/barcode_check'
+
+
 module JSONModel
   module Validations
 


### PR DESCRIPTION

config looks like this:
AppConfig[:yale_containers_barcode_length] = {
  :system_default => {:min => 5, :max => 10},
  :repository_2 => {:min => 8, :max => 12}
}

Some of the remaining ugliness arises from trying to give the user a hope of guessing how long her barcode can be. Alternative approaches welcome.

