### PR TITLE
[Delivers #82733622] Handle multiple linked records in the container display string

### DIFF
--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -132,22 +132,22 @@ describe 'Yale Container model' do
     it "can find an accession linked to a given top container" do
       accession = create_accession({"instances" => [build_instance(box)]})
 
-      collection = top_container.collection
+      collection = top_container.collections.first
       collection.should be_instance_of(Accession)
       collection.id.should eq(accession.id)
 
-      top_container.series.should be_nil
+      top_container.series.should be_empty
     end
 
 
     it "can find a resource linked to a given top container" do
       resource = create_resource({"instances" => [build_instance(box)]})
 
-      collection = top_container.collection
+      collection = top_container.collections.first
       collection.should be_instance_of(Resource)
       collection.id.should eq(resource.id)
 
-      top_container.series.should be_nil
+      top_container.series.should be_empty
     end
 
 
@@ -156,7 +156,7 @@ describe 'Yale Container model' do
       it "can find the topmost archival object linked to a given top container" do
         (resource, grandparent, parent, child) = create_tree(box)
 
-        series = top_container.series
+        series = top_container.series.first
         series.should be_instance_of(ArchivalObject)
         series.id.should eq(grandparent.id)
       end
@@ -169,7 +169,7 @@ describe 'Yale Container model' do
                                                              })
 
         json = TopContainer.to_jsonmodel(top_container.id)
-        json.series.should eq({
+        json.series.first.should eq({
           'ref' => grandparent.uri,
           'identifier' => grandparent.component_id,
           'display_string' => grandparent.display_string,
@@ -180,7 +180,7 @@ describe 'Yale Container model' do
       it "can get the collection linked to a given top container" do
         (resource, grandparent, parent, child) = create_tree(box)
 
-        collection = top_container.collection
+        collection = top_container.collections.first
         collection.should be_instance_of(Resource)
         collection.id.should eq(resource.id)
       end

--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -83,7 +83,9 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
     selectorHeaders: "thead tr.sortable-columns th",
     // disable sort on the checkbox column
     headers: {
-      0: { sorter: false}
+        0: { sorter: false},
+        9: { sorter: false},
+        10: { sorter: false}
     },
     // default sort: Collection, Series, Indicator
     sortList: [[1,0],[3,0],[4,0],[6,0]]

--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -94,7 +94,7 @@ class TopContainersController < ApplicationController
     begin
       results = perform_search if params.has_key?("q")
     rescue MissingFilterException
-      return render :text => I18n.t("top_container._frontend.messages.filter_required"), :status => 500
+      flash[:error] = I18n.t("top_container._frontend.messages.filter_required")
     end
 
     render_aspace_partial :partial => "top_containers/bulk_operations/browse", :locals => {:results => results}

--- a/frontend/views/top_containers/bulk_operations/_browse.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_browse.html.erb
@@ -1,3 +1,5 @@
+<%= render_aspace_partial :partial => "shared/flash_messages" %>
+
 <div id="topContainerBrowseContainer">
   <%= render_aspace_partial :partial => "top_containers/bulk_operations/search_criteria", :locals => {:form_target => {:controller => :top_containers, :action => :bulk_operations_browse}} %>
   <% unless results.nil? %>

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -17,19 +17,8 @@
 
 <table class="table table-striped table-bordered table-condensed table-hover table-sortable table-search-results">
   <thead>
-    <tr>
-      <th></th>
-      <th colspan="2">Collection/Accession</th>
-      <th colspan="2">Series</th>
-      <th colspan="8">Top Container</th>
-      <th></th>
-    </tr>
     <tr class="sortable-columns">
       <th><% if multiselect %><%= check_box_tag "select_all" %><% end %></th>
-      <th>ID</th>
-      <th>Title</th>
-      <th>Level</th>
-      <th>ID</th>
       <th>Container Profile</th>
       <th>Indicator</th>
       <th>Barcode</th>
@@ -38,6 +27,7 @@
       <th>ILS Item ID</th>
       <th>Restricted?</th>
       <th>Exported</th>
+      <th>Linked records</th>
       <th><!-- Actions --></th>
     </tr>
   </thead>
@@ -52,35 +42,6 @@
             <%= radio_button_tag "linker-item", container_json["uri"], false, :"data-object" => container_json.to_json %>
           <% end %>
         </td>
-        <td>
-            <ul>
-            <% Array(doc['collection_identifier_u_stext']).each do |id| %>
-                <li><%= id %></li>
-            <% end %>
-            </ul>
-        </td>
-        <td>
-            <ul>
-            <% Array(doc['collection_display_string_u_sstr']).each do |id| %>
-                <li><%= id %></li>
-            <% end %>
-            </ul>
-        </td>
-        <td>
-            <ul>
-            <% Array(doc['series_level_u_sstr']).each do |id| %>
-                <li><%= id %></li>
-            <% end %>
-            </ul>
-        </td>
-        <td>
-            <ul>
-            <% Array(doc['series_identifier_u_stext']).each do |id| %>
-                <li><%= id %></li>
-            <% end %>
-            </ul>
-        </td>
-
         <td><%= Array(doc['container_profile_display_string_u_sstr']).first %></td>
         <td><%= container_json['indicator'] %></td>
         <td><%= container_json['barcode'] %></td>
@@ -93,6 +54,56 @@
         <% else %>
           <td><%= container_json['exported_to_ils'] %></td>
         <% end %>
+
+        <!-- <td>
+        <ul>
+        <% Array(doc['collection_identifier_u_stext']).each do |id| %>
+            <li><%= id %></li>
+        <% end %>
+        </ul>
+        </td>
+        <td>
+        <ul>
+        <% Array(doc['collection_display_string_u_sstr']).each do |id| %>
+            <li><%= id %></li>
+        <% end %>
+        </ul>
+        </td>
+        <td>
+        <ul>
+        <% Array(doc['series_level_u_sstr']).each do |id| %>
+            <li><%= id %></li>
+        <% end %>
+        </ul>
+        </td>
+        <td>
+        <ul>
+        <% Array(doc['series_identifier_u_stext']).each do |id| %>
+            <li><%= id %></li>
+        <% end %>
+        </ul>
+        </td> -->
+
+
+         <td>
+            <dl>
+
+                <% if doc['collection_identifier_u_stext'] %>
+                    <dt>Collection</dt>
+                    <% Array(doc['collection_identifier_u_stext']).zip(Array(doc['collection_display_string_u_sstr'])).each do |identifier, display| %>
+                        <dd><%= identifier %> - <%= display %></dd>
+                    <% end %>
+                <% end %>
+
+                <% if doc['series_level_u_sstr'] %>
+                    <dt>Series</dt>
+                    <% Array(doc['series_level_u_sstr']).zip(Array(doc['series_identifier_u_stext'])).each do |level, identifier| %>
+                        <dd><%= level %> - <%= identifier %></dd>
+                    <% end %>
+                <% end %>
+            </dl>
+        </td>
+
         <td>
           <div class="btn-group pull-right">
             <%= link_to I18n.t("actions.view"), {:controller => :resolver, :action => :resolve_readonly, :uri => container_json["uri"]}, :class => "btn btn-mini" %>

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -52,10 +52,35 @@
             <%= radio_button_tag "linker-item", container_json["uri"], false, :"data-object" => container_json.to_json %>
           <% end %>
         </td>
-        <td><%= Array(doc['collection_identifier_u_stext']).first %></td>
-        <td><%= Array(doc['collection_display_string_u_sstr']).first %></td>
-        <td><%= Array(doc['series_level_u_sstr']).first %></td>
-        <td><%= Array(doc['series_identifier_u_stext']).first %></td>
+        <td>
+            <ul>
+            <% Array(doc['collection_identifier_u_stext']).each do |id| %>
+                <li><%= id %></li>
+            <% end %>
+            </ul>
+        </td>
+        <td>
+            <ul>
+            <% Array(doc['collection_display_string_u_sstr']).each do |id| %>
+                <li><%= id %></li>
+            <% end %>
+            </ul>
+        </td>
+        <td>
+            <ul>
+            <% Array(doc['series_level_u_sstr']).each do |id| %>
+                <li><%= id %></li>
+            <% end %>
+            </ul>
+        </td>
+        <td>
+            <ul>
+            <% Array(doc['series_identifier_u_stext']).each do |id| %>
+                <li><%= id %></li>
+            <% end %>
+            </ul>
+        </td>
+
         <td><%= Array(doc['container_profile_display_string_u_sstr']).first %></td>
         <td><%= container_json['indicator'] %></td>
         <td><%= container_json['barcode'] %></td>

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -88,16 +88,16 @@
          <td>
             <dl>
 
-                <% if doc['collection_identifier_u_stext'] %>
+                <% if doc['collection_identifier_stored_u_sstr'] %>
                     <dt>Collection</dt>
-                    <% Array(doc['collection_identifier_u_stext']).zip(Array(doc['collection_display_string_u_sstr'])).each do |identifier, display| %>
+                    <% Array(doc['collection_identifier_stored_u_sstr']).zip(Array(doc['collection_display_string_u_sstr'])).each do |identifier, display| %>
                         <dd><%= identifier %> - <%= display %></dd>
                     <% end %>
                 <% end %>
 
                 <% if doc['series_level_u_sstr'] %>
                     <dt>Series</dt>
-                    <% Array(doc['series_level_u_sstr']).zip(Array(doc['series_identifier_u_stext'])).each do |level, identifier| %>
+                    <% Array(doc['series_level_u_sstr']).zip(Array(doc['series_identifier_stored_u_sstr'])).each do |level, identifier| %>
                         <dd><%= level %> - <%= identifier %></dd>
                     <% end %>
                 <% end %>

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -16,21 +16,29 @@ class CommonIndexer
     indexer.add_document_prepare_hook {|doc, record|
       if record['record']['jsonmodel_type'] == 'top_container'
         doc['title'] = record['record']['display_string']
+
         if record['record']['series']
-          doc['series_uri_u_sstr'] = record['record']['series']['ref']
-          doc['series_title_u_sstr'] = record['record']['series']['display_string']
-          doc['series_level_u_sstr'] = record['record']['series']['level_display_string']
-          doc['series_identifier_u_stext'] = CommonIndexer.generate_permutations_for_identifier(record['record']['series']['identifier'])
+          doc['series_uri_u_sstr'] = record['record']['series'].map {|series| series['ref']}
+          doc['series_title_u_sstr'] = record['record']['series'].map {|series| series['display_string']}
+          doc['series_level_u_sstr'] = record['record']['series'].map {|series| series['level_display_string']}
+          doc['series_identifier_u_stext'] = record['record']['series'].map {|series|
+            CommonIndexer.generate_permutations_for_identifier(series['identifier'])
+          }.flatten
         end
+
         if record['record']['collection']
-          doc['collection_uri_u_sstr'] = record['record']['collection']['ref']
-          doc['collection_display_string_u_sstr'] = record['record']['collection']['display_string']
-          doc['collection_identifier_u_stext'] = CommonIndexer.generate_permutations_for_identifier(record['record']['collection']['identifier'])
+          doc['collection_uri_u_sstr'] = record['record']['collection'].map {|collection| collection['ref']}
+          doc['collection_display_string_u_sstr'] = record['record']['collection'].map {|collection| collection['display_string']}
+          doc['collection_identifier_u_stext'] = record['record']['collection'].map {|collection|
+            CommonIndexer.generate_permutations_for_identifier(collection['identifier'])
+          }.flatten
         end
+
         if record['record']['container_profile']
           doc['container_profile_uri_u_sstr'] = record['record']['container_profile']['ref']
           doc['container_profile_display_string_u_sstr'] = record['record']['container_profile']['_resolved']['display_string']
         end
+
         if record['record']['container_locations'].length > 0
           record['record']['container_locations'].each do |container_location|
             if container_location['status'] == 'current'

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -21,6 +21,7 @@ class CommonIndexer
           doc['series_uri_u_sstr'] = record['record']['series'].map {|series| series['ref']}
           doc['series_title_u_sstr'] = record['record']['series'].map {|series| series['display_string']}
           doc['series_level_u_sstr'] = record['record']['series'].map {|series| series['level_display_string']}
+          doc['series_identifier_stored_u_sstr'] = record['record']['series'].map {|series| series['identifier']}
           doc['series_identifier_u_stext'] = record['record']['series'].map {|series|
             CommonIndexer.generate_permutations_for_identifier(series['identifier'])
           }.flatten
@@ -29,6 +30,7 @@ class CommonIndexer
         if record['record']['collection']
           doc['collection_uri_u_sstr'] = record['record']['collection'].map {|collection| collection['ref']}
           doc['collection_display_string_u_sstr'] = record['record']['collection'].map {|collection| collection['display_string']}
+          doc['collection_identifier_stored_u_sstr'] = record['record']['collection'].map {|collection| collection['identifier']}
           doc['collection_identifier_u_stext'] = record['record']['collection'].map {|collection|
             CommonIndexer.generate_permutations_for_identifier(collection['identifier'])
           }.flatten

--- a/schemas/top_container.rb
+++ b/schemas/top_container.rb
@@ -42,38 +42,44 @@
 
       "series" => {
         "readonly" => "true",
-        "type" => "object",
-        "subtype" => "ref",
-        "properties" => {
-          "ref" => {
-            "type" => "JSONModel(:archival_object) uri",
-          },
-          "display_string" => {"type" => "string"},
-          "identifier" => {"type" => "string"},
-          "level_display_string" => {"type" => "string"},
-          "_resolved" => {
-            "type" => "object",
-            "readonly" => "true"
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "subtype" => "ref",
+          "properties" => {
+            "ref" => {
+              "type" => "JSONModel(:archival_object) uri",
+            },
+            "display_string" => {"type" => "string"},
+            "identifier" => {"type" => "string"},
+            "level_display_string" => {"type" => "string"},
+            "_resolved" => {
+              "type" => "object",
+              "readonly" => "true"
+            }
           }
         }
       },
 
       "collection" => {
         "readonly" => "true",
-        "type" => "object",
-        "subtype" => "ref",
-        "properties" => {
-          "ref" => {
-            "type" => [
-              {"type" => "JSONModel(:resource) uri"},
-              {"type" => "JSONModel(:accession) uri"}
-            ]
-          },
-          "display_string" => {"type" => "string"},
-          "identifier" => {"type" => "string"},
-          "_resolved" => {
-            "type" => "object",
-            "readonly" => "true"
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "subtype" => "ref",
+          "properties" => {
+            "ref" => {
+              "type" => [
+                {"type" => "JSONModel(:resource) uri"},
+                {"type" => "JSONModel(:accession) uri"}
+              ]
+            },
+            "display_string" => {"type" => "string"},
+            "identifier" => {"type" => "string"},
+            "_resolved" => {
+              "type" => "object",
+              "readonly" => "true"
+            }
           }
         }
       }


### PR DESCRIPTION
From the pivotal comment: 

"We need additional ID and Titles to show up in the same row. Example: ID = MS-1234; Accession 2014;j MS-411, and Title = ArchivessSpace Committee records; accession title; ms-411 title."