### PR TITLE
Top container delete

### DIFF
--- a/backend/controllers/container.rb
+++ b/backend/controllers/container.rb
@@ -1,7 +1,7 @@
 class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/repositories/:repo_id/top_containers/search')
-  .description("Delete a yale container")
+  .description("Search for yale containers")
   .params(["repo_id", :repo_id],
           *BASE_SEARCH_PARAMS)
   .permissions([:view_repository])

--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -101,21 +101,24 @@ describe 'Yale Container model' do
   end
 
 
-  it "can't delete a TopContainer that has been linked to a sub container" do
-    box = create(:json_top_container)
+  it "deletes all related subcontainers and instances when deleted" do
+    box1 = create(:json_top_container)
+    box2 = create(:json_top_container)
 
-    accession = create_accession({
-                                   "instances" => [build_instance(box)]
-                                 })
+    acc1 = create_accession({
+                              "instances" => [build_instance(box1), build_instance(box1), build_instance(box2)]
+                            })
 
+    acc2 = create_accession({
+                              "instances" => [build_instance(box1), build_instance(box2), build_instance(box2)]
+                            })
 
-    expect { TopContainer[box.id].delete }.to raise_error(ConflictException)
-  end
+    TopContainer[box1.id].delete
 
-  it "can delete a TopContainer that has not been linked to a sub container" do
-    box = create(:json_top_container)
-
-    expect { TopContainer[box.id].delete }.to_not raise_error
+    acc1 = Accession[acc1.id]
+    acc2 = Accession[acc2.id]
+    acc1.instance.length.should eq(1)
+    acc2.instance.length.should eq(2)
   end
 
 

--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -7,6 +7,7 @@ function BulkContainerSearch($search_form, $results_container, $toolbar) {
   this.setup_results_list();
   this.setup_bulk_action_test();
   this.setup_bulk_action_update_ils_holding();
+  this.setup_bulk_action_delete();
 }
 
 function BulkContainerUpdate($update_form) {
@@ -137,6 +138,19 @@ BulkContainerSearch.prototype.setup_bulk_action_update_ils_holding = function() 
   $link.on("click", function() {
     var updateUris = self.get_selection().map(function(c) { return c[0] });
     AS.openCustomModal("bulkUpdateModal", "Update ILS Holding IDs", AS.renderTemplate("bulk_action_update_ils_holding", {
+      selection: self.get_selection(),
+      updateUris: updateUris
+    }), 'full')
+  });
+};
+
+BulkContainerSearch.prototype.setup_bulk_action_delete = function() {
+  var self = this;
+  var $link = $("#bulkActionDelete", self.$toolbar);
+
+  $link.on("click", function() {
+    var updateUris = self.get_selection().map(function(c) { return c[0] });
+    AS.openCustomModal("bulkActionModal", "Delete Top Containers", AS.renderTemplate("bulk_action_delete", {
       selection: self.get_selection(),
       updateUris: updateUris
     }), 'full')

--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -76,11 +76,18 @@ BulkContainerSearch.prototype.setup_results_list = function(docs) {
 
 BulkContainerSearch.prototype.update_button_state = function() {
   var self = this;
+  var checked_boxes = $("tbody :checkbox:checked", self.$results_container);
+  var delete_btn = self.$toolbar.find(".btn");
 
-  if ($("tbody :checkbox:checked", self.$results_container).length > 0) {
-    self.$toolbar.find(".btn").removeClass("disabled").removeAttr("disabled");
+  if (checked_boxes.length > 0) {
+    var selected_records = $.makeArray(checked_boxes.map(function() {return $(this).val();}));
+    delete_btn.data("form-data", {
+      record_uris: selected_records
+    });
+    delete_btn.removeClass("disabled").removeAttr("disabled");
   } else {
-    self.$toolbar.find(".btn").addClass("disabled").attr("disabled", "disabled");
+    delete_btn.data("form-data", {});
+    delete_btn.addClass("disabled").attr("disabled", "disabled");
   }
 };
 

--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -1,7 +1,7 @@
 class TopContainersController < ApplicationController
 
   set_access_control  "view_repository" => [:index, :show, :typeahead, :bulk_operations_browse],
-                      "manage_container" => [:new, :create, :edit, :update, :batch_delete, :bulk_operations, :bulk_operation_search, :bulk_operation_update]
+                      "manage_container" => [:new, :create, :edit, :update, :delete, :batch_delete, :bulk_operations, :bulk_operation_search, :bulk_operation_update]
 
 
   def index
@@ -59,7 +59,10 @@ class TopContainersController < ApplicationController
 
 
   def delete
-    raise "TODO"
+    top_container = JSONModel(:top_container).find(params[:id])
+    top_container.delete
+
+    redirect_to(:controller => :top_containers, :action => :index, :deleted_uri => top_container.uri)
   end
 
   def batch_delete

--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -66,7 +66,19 @@ class TopContainersController < ApplicationController
   end
 
   def batch_delete
-    raise "TODO"
+    response = JSONModel::HTTP.post_form("/batch_delete",
+                                         {
+                                "record_uris[]" => Array(params[:record_uris])
+                                         })
+
+    if response.code === "200"
+      flash[:success] = I18n.t("top_container.batch_delete.success")
+      deleted_uri_param = params[:record_uris].map{|uri| "deleted_uri[]=#{uri}"}.join("&")
+      redirect_to "#{request.referrer}?#{deleted_uri_param}"
+    else
+      flash[:error] = "#{I18n.t("top_container.batch_delete.error")}<br/> #{ASUtils.json_parse(response.body)["error"]["failures"].map{|err| "#{err["response"]} [#{err["uri"]}]"}.join("<br/>")}".html_safe
+      redirect_to request.referrer
+    end
   end
 
 

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -39,6 +39,10 @@ en:
     barcode_length_for_this_repository: "Barcode length for this repository:"
     characters: characters
 
+    batch_delete:
+      success: Top Containers successfully deleted
+      error: There was a problem deleting Top Containers
+
     _singular: Top Container
     _plural: Top Containers
 

--- a/frontend/routes.rb
+++ b/frontend/routes.rb
@@ -6,6 +6,7 @@ ArchivesSpace::Application.routes.draw do
   match('/plugins/top_containers/bulk_operations/update' => 'top_containers#bulk_operation_update', :via => [:post])
   match('/plugins/top_containers/batch_delete' => 'top_containers#batch_delete', :via => [:post])
   match('/plugins/top_containers/:id' => 'top_containers#update', :via => [:post])
+  match('/plugins/top_containers/:id/delete' => 'top_containers#delete', :via => [:post])
 
   match('/plugins/container_profiles/:id' => 'container_profiles#update', :via => [:post])
   match('/plugins/container_profiles/:id/delete' => 'container_profiles#delete', :via => [:post])

--- a/frontend/views/top_containers/_toolbar.html.erb
+++ b/frontend/views/top_containers/_toolbar.html.erb
@@ -13,13 +13,13 @@
           </div>
         <% end %>
         <% if !['new'].include?(controller.action_name) %>
-        <!-- <div class="btn-toolbar pull-right">
+        <div class="btn-toolbar pull-right">
           <div class="btn-group">
             <div class="btn btn-inline-form">
-              <%# button_delete_action url_for(:controller => :top_containers, :action => :delete, :id => @top_container.id) unless @top_container.id.nil? %>
+              <%= button_delete_action url_for(:controller => :top_containers, :action => :delete, :id => @top_container.id) unless @top_container.id.nil? %>
             </div>
           </div>
-        </div> -->
+        </div>
         <% end %>
       </div>
     </div>

--- a/frontend/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
@@ -39,3 +39,28 @@
   <script>new BulkContainerUpdate($("#bulk_update_form"));</script>
 
 --></div>
+
+<div id="bulk_action_delete"><!--
+  <%= form_tag({:controller => :top_containers, :action => :batch_delete}, {:class => "form-horizontal", :id => "batch_delete_form" }) do |f| %>
+    <div class="modal-body">
+        <div class="alert alert-info" id="alertBucket">Delete all selected containers.</div>
+
+        <div class="selected-record-list well">
+            <ul>
+                {for container in selection}
+                <li>${container[1]}</li>
+                {/for}
+            </ul>
+        </div>
+
+        {for uri in updateUris}
+        <input type="hidden" name="record_uris[]" value="${uri}">
+        {/for}
+    </div>
+    <div class="modal-footer">
+        <button type="submit" class="btn btn-primary">Delete ${selection.length} records</button>
+        <button class="btn btn-cancel" data-dismiss="modal"><%= I18n.t("actions.cancel") %></button>
+    </div>
+  <% end %>
+
+--></div>

--- a/frontend/views/top_containers/bulk_operations/_search_criteria.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_search_criteria.html.erb
@@ -4,6 +4,7 @@
 <div class="row-fluid">
   <div class="span12">
     <h1><%= I18n.t("top_container._plural") %></h1>
+    <%= render_aspace_partial :partial => "shared/flash_messages" %>
     <%= form_tag(form_target, {:class => "form-horizontal", :id => "bulk_operation_form"}) do |f| %>
       <div class="span8">
         <div class="control-group">

--- a/frontend/views/top_containers/bulk_operations/_toolbar.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_toolbar.html.erb
@@ -8,15 +8,8 @@
       <ul class="dropdown-menu">
         <li><a id="bulkActionTestSelection" href="javascript:void(0)">Test Selection</a></li>
         <li><a id="bulkActionUpdateIlsHolding" href="javascript:void(0)">Update ILS Holding IDs</a></li>
+        <li><a id="bulkActionDelete" href="javascript:void(0)">Delete Top Containers</a></li>
       </ul>
     </div>
-    <%= button_delete_action(url_for(:controller => :top_containers, :action => :batch_delete), {
-      :class => "btn btn-small btn-danger multiselect-enabled",
-      :"data-multiselect" => "#tabledSearchResults",
-      :"data-title" => I18n.t("actions.delete_multiple_confirm_title"),
-      :"data-message" => I18n.t("actions.delete_multiple_confirm_message"),
-      :"data-confirm-btn-label" => "#{I18n.t("actions.delete_multiple")}",
-      :disabled => "disabled"
-    }) %>
   </div>
 </div>


### PR DESCRIPTION
[Delivers 84087370]
Supports deleting top container records individually, or in a bulk operation.
When a top container is deleted, all instances linked to it are also deleted.
There was also a request to delete top containers automatically when their last linking instance is deleted. This has not been implemented - see piv story for reasons.
