### PR TITLE
[Delivers #82734844] Reintroduce sorting of top containers by collection or series

### DIFF
--- a/frontend/assets/top_containers.bulk.css
+++ b/frontend/assets/top_containers.bulk.css
@@ -1,3 +1,6 @@
+#bulk_operation_results .table-sortable th.header {
+    cursor: pointer;
+}
 #bulk_operation_results .table-sortable th.header.headerSortUp,
 #bulk_operation_results .table-sortable th.header.headerSortDown {
     padding-right: 20px;
@@ -28,4 +31,12 @@
 .selected-record-list {
     max-height: 180px;
     overflow: auto;
+}
+
+#bulk_operation_results .linked-records-listing {
+    margin: 0;
+    list-style-position: inside;
+}
+#bulk_operation_results .linked-records-listing.count-1 {
+    list-style: none;
 }

--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -90,12 +90,29 @@ BulkContainerSearch.prototype.setup_table_sorter = function() {
     selectorHeaders: "thead tr.sortable-columns th",
     // disable sort on the checkbox column
     headers: {
-        0: { sorter: false},
-        9: { sorter: false},
-        10: { sorter: false}
+        0: { sorter: false}
     },
     // default sort: Collection, Series, Indicator
-    sortList: [[1,0],[3,0],[4,0],[6,0]]
+    sortList: [[1,0],[2,0],[4,0]],
+    // customise text extraction to pull only the first collection/series
+    textExtraction: function(node) {
+      var $node = $(node);
+
+      if ($node.hasClass("top-container-collection")) {
+        return $node.find(".collection-identifier:first").text().trim();
+      } else if ($node.hasClass("top-container-series")) {
+        var level = $node.find(".series-level:first").text().trim();
+        var identifier = $node.find(".series-identifier:first").text().trim();
+
+        if ((level+identifier).length > 0) {
+          return level + "-" + identifier;
+        } else {
+          return "";
+        }
+      }
+
+      return $node.text().trim();
+    }
   };
   this.$results_container.find("table").tablesorter(tablesorter_opts);
 };

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -20,6 +20,8 @@
   <thead>
     <tr class="sortable-columns">
       <th><% if multiselect %><%= check_box_tag "select_all" %><% end %></th>
+      <th>Resource/Accession</th>
+      <th>Series</th>
       <th>Container Profile</th>
       <th>Indicator</th>
       <th>Barcode</th>
@@ -28,7 +30,6 @@
       <th>ILS Item ID</th>
       <th>Restricted?</th>
       <th>Exported</th>
-      <th>Linked records</th>
       <% if show_edit_actions %><th><!-- Actions --></th><% end %>
     </tr>
   </thead>
@@ -43,6 +44,24 @@
             <%= radio_button_tag "linker-item", container_json["uri"], false, :"data-object" => container_json.to_json %>
           <% end %>
         </td>
+        <td class="top-container-collection">
+          <% if doc['collection_identifier_stored_u_sstr'] %>
+            <ul class="linked-records-listing count-<%= Array(doc['collection_identifier_stored_u_sstr']).length %>">
+              <% Array(doc['collection_identifier_stored_u_sstr']).zip(Array(doc['collection_display_string_u_sstr'])).each do |identifier, display| %>
+                <li><span class="collection-identifier"><%= identifier %></span> <span class="collection-display-string"><%= display %></span</li>
+              <% end %>
+            </ul>
+          <% end %>
+        </td>
+        <td class="top-container-series">
+          <% if doc['series_level_u_sstr'] %>
+            <ul class="linked-records-listing count-<%= Array(doc['series_level_u_sstr']).length %>">
+              <% Array(doc['series_level_u_sstr']).zip(Array(doc['series_identifier_stored_u_sstr'])).each do |level, identifier| %>
+                <li><span class="series-level"><%= level %></span> <span class="series-identifier"><%= identifier %></span></li>
+              <% end %>
+            </ul>
+          <% end %>
+        </td>
         <td><%= Array(doc['container_profile_display_string_u_sstr']).first %></td>
         <td><%= container_json['indicator'] %></td>
         <td><%= container_json['barcode'] %></td>
@@ -55,55 +74,6 @@
         <% else %>
           <td><%= container_json['exported_to_ils'] %></td>
         <% end %>
-
-        <!-- <td>
-        <ul>
-        <% Array(doc['collection_identifier_u_stext']).each do |id| %>
-            <li><%= id %></li>
-        <% end %>
-        </ul>
-        </td>
-        <td>
-        <ul>
-        <% Array(doc['collection_display_string_u_sstr']).each do |id| %>
-            <li><%= id %></li>
-        <% end %>
-        </ul>
-        </td>
-        <td>
-        <ul>
-        <% Array(doc['series_level_u_sstr']).each do |id| %>
-            <li><%= id %></li>
-        <% end %>
-        </ul>
-        </td>
-        <td>
-        <ul>
-        <% Array(doc['series_identifier_u_stext']).each do |id| %>
-            <li><%= id %></li>
-        <% end %>
-        </ul>
-        </td> -->
-
-
-         <td>
-            <dl>
-
-                <% if doc['collection_identifier_stored_u_sstr'] %>
-                    <dt>Collection</dt>
-                    <% Array(doc['collection_identifier_stored_u_sstr']).zip(Array(doc['collection_display_string_u_sstr'])).each do |identifier, display| %>
-                        <dd><%= identifier %> - <%= display %></dd>
-                    <% end %>
-                <% end %>
-
-                <% if doc['series_level_u_sstr'] %>
-                    <dt>Series</dt>
-                    <% Array(doc['series_level_u_sstr']).zip(Array(doc['series_identifier_stored_u_sstr'])).each do |level, identifier| %>
-                        <dd><%= level %> - <%= identifier %></dd>
-                    <% end %>
-                <% end %>
-            </dl>
-        </td>
 
         <% if show_edit_actions %>
         <td>


### PR DESCRIPTION
After feedback requesting we reinstate the sorting by collection/series.  

This patch reintroduces the Resource/Accession and Series columns.  When a top container is linked to multiple collections/series only take the first entry when determining the sort order.  

For collections, sort is based on the first  identifier in the cell.  For series, sort is based on the first linked series' level and identifier combined.  This achieved with a custom textextraction configuration on the jquery tablesorter.