### PR TITLE
Calculate container restriction

### DIFF
--- a/backend/model/accession_ext.rb
+++ b/backend/model/accession_ext.rb
@@ -1,0 +1,1 @@
+Accession.include(RightsStatementRestrictions)

--- a/backend/model/archival_object_ext.rb
+++ b/backend/model/archival_object_ext.rb
@@ -1,2 +1,3 @@
 ArchivalObject.include(ReindexTopContainers)
 ArchivalObject.include(ArchivalObjectSeries)
+ArchivalObject.include(RightsStatementRestrictions)

--- a/backend/model/mixins/reindex_top_containers.rb
+++ b/backend/model/mixins/reindex_top_containers.rb
@@ -1,6 +1,9 @@
 module ReindexTopContainers
 
   def reindex_top_containers
+    # get out if we aren't part of a resource tree
+    # TODO: look at this - we probably need to touch this record's top containers at least
+    return unless self.root_record_id
     # Find any relationships between a top container and any instance within the current tree.
     tree_object_graph = self.class.root_model[self.root_record_id].object_graph
     top_container_link_rlshp = SubContainer.find_relationship(:top_container_link)

--- a/backend/model/mixins/reindex_top_containers.rb
+++ b/backend/model/mixins/reindex_top_containers.rb
@@ -1,11 +1,10 @@
 module ReindexTopContainers
 
   def reindex_top_containers
-    # get out if we aren't part of a resource tree
-    # TODO: look at this - we probably need to touch this record's top containers at least
-    return unless self.root_record_id
     # Find any relationships between a top container and any instance within the current tree.
-    tree_object_graph = self.class.root_model[self.root_record_id].object_graph
+    root_record = self.root_record_id ? self.class.root_model[self.root_record_id] : self.series
+
+    tree_object_graph = root_record.object_graph
     top_container_link_rlshp = SubContainer.find_relationship(:top_container_link)
     relationship_ids = tree_object_graph.ids_for(top_container_link_rlshp)
 

--- a/backend/model/mixins/rights_statement_restrictions.rb
+++ b/backend/model/mixins/rights_statement_restrictions.rb
@@ -1,0 +1,28 @@
+module RightsStatementRestrictions
+
+  def restricted_by_rights?
+    rights_statement.any? do |rs|
+      if rs.active == 1
+        start = rs.restriction_start_date
+        start &&= start.to_time
+        enddd = rs.restriction_end_date
+        enddd &&= enddd.to_time
+
+        now = Time.now
+
+        if enddd && (enddd < now)
+          # end date has already happened.  Not applicable.
+          return false
+        elsif start && (start > now)
+          # start date hasn't been reached yet.  Not applicable
+          return false
+        else
+          return true
+        end
+
+      end
+    end
+  end
+
+end
+

--- a/backend/model/resource_ext.rb
+++ b/backend/model/resource_ext.rb
@@ -1,0 +1,1 @@
+Resource.include(RightsStatementRestrictions)

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -167,24 +167,7 @@ class TopContainer < Sequel::Model(:top_container)
 
 
   def rights_restricted_contents
-    restricted_items = []
-    linked_archival_records.each do |ao|
-      ao.rights_statement.each do |rs|
-        if rs.active == 1
-          start = rs.restriction_start_date
-          start &&= start.to_time
-          enddd = rs.restriction_end_date
-          enddd &&= enddd.to_time
-
-          if (!start && !enddd) ||
-              ((start && start <= Time.now) && (!enddd || enddd >= Time.now)) ||
-              ((enddd && enddd >= Time.now) && (!start || start <= Time.now))
-              restricted_items << ao
-          end
-        end
-      end
-    end
-    restricted_items.uniq {|obj| obj.uri}
+    linked_archival_records.select {|ao| ao.restricted_by_rights?}.uniq(&:uri)
   end
 
 

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -178,7 +178,7 @@ class TopContainer < Sequel::Model(:top_container)
         end
       end
     end
-    restricted_items
+    restricted_items.uniq {|obj| obj.uri}
   end
 
 

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -142,7 +142,7 @@ class TopContainer < Sequel::Model(:top_container)
         json['exported_to_ils'] = json['exported_to_ils'].getlocal.iso8601
       end
 
-      json['restricted'] = obj.restricted_by_rights?
+      json['restricted'] = obj.restricted_by_rights? if obj.override_restricted == 0
     end
 
     jsons

--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -75,12 +75,18 @@ class TopContainer < Sequel::Model(:top_container)
   def collections
     linked_archival_records.map {|obj|
       if obj.respond_to?(:series)
-        obj.class.root_model[obj.root_record_id]
+        # An Archival Object
+        if obj.root_record_id
+          obj.class.root_model[obj.root_record_id]
+        else
+          # An Archival Object without a resource.  Doesn't really happen in
+          # normal usage, but the data model does support this...
+          nil
+        end
       else
         obj
       end
     }.compact.uniq {|obj| obj.uri}
-    # added compact above because a test was bombing saying obj was nil. should investigate JJJ
   end
 
 

--- a/backend/spec/factories.rb
+++ b/backend/spec/factories.rb
@@ -7,7 +7,6 @@ FactoryGirl.define do
     barcode { generate(:alphanumstr) }
     ils_holding_id { generate(:alphanumstr) }
     ils_item_id { generate(:alphanumstr) }
-    restricted { false }
     exported_to_ils { Time.now.iso8601 }
   end
 

--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -53,6 +53,12 @@ end
 
 describe 'Yale Container model' do
 
+  before(:each) do
+    # Permissive default!
+    stub_barcode_length(0, 255)
+  end
+
+
   it "supports all kinds of wonderful metadata" do
     barcode = '12345678'
     ils_holding_id = '112358'

--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -401,6 +401,22 @@ describe 'Yale Container model' do
       JSONModel(:top_container).find(topcon2.id).restricted.should eq(false)
     end
 
+
+    it "allows the calculated value for restricted to be overridden" do
+      Time.stub!(:now).and_return(Time.at(0))
+
+      topcon1 = create(:json_top_container)
+      create_archival_object_with_rights(topcon1, [["19720120", "19740809"]])
+      JSONModel(:top_container).find(topcon1.id).restricted.should eq(false)
+
+      puts "topcon1 #{topcon1.inspect}"      
+
+      topcon1 = JSONModel(:top_container).find(topcon1.id)
+      topcon1.override_restricted = true
+      topcon1.restricted = true
+      topcon1.save
+      JSONModel(:top_container).find(topcon1.id).restricted.should eq(true)
+    end
   end
 
   describe "bulk action" do

--- a/backend/spec/model_yale_container_spec.rb
+++ b/backend/spec/model_yale_container_spec.rb
@@ -409,8 +409,6 @@ describe 'Yale Container model' do
       create_archival_object_with_rights(topcon1, [["19720120", "19740809"]])
       JSONModel(:top_container).find(topcon1.id).restricted.should eq(false)
 
-      puts "topcon1 #{topcon1.inspect}"      
-
       topcon1 = JSONModel(:top_container).find(topcon1.id)
       topcon1.override_restricted = true
       topcon1.restricted = true

--- a/frontend/assets/top_containers.crud.js
+++ b/frontend/assets/top_containers.crud.js
@@ -1,1 +1,16 @@
 //= require form
+
+$(function () {
+	var init = function () {
+	    $('#top_container_override_restricted_').on('click', function (event) {
+		    event.stopPropagation();
+		    if ($(this).is(":checked")) {
+			$('#top_container_restricted_').removeAttr("disabled");
+		    } else {
+			$('#top_container_restricted_').attr("disabled", "disabled");;
+		    }
+		});
+	};
+
+	init();
+    });

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -29,6 +29,7 @@ en:
     exported_to_ils: Exported to ILS
     not_exported: Not exported
     restricted: Restricted?
+    override_restricted: Override restricted?
     parent: Parent Container
 
     yale_container_2_type: Child Container Type

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -29,7 +29,8 @@ en:
     exported_to_ils: Exported to ILS
     not_exported: Not exported
     restricted: Restricted?
-    override_restricted: Override restricted?
+    override_restricted: Override Restricted?
+    rights_restricted_contents: Rights Restricted Contents
     parent: Parent Container
 
     yale_container_2_type: Child Container Type

--- a/frontend/views/top_containers/_form.html.erb
+++ b/frontend/views/top_containers/_form.html.erb
@@ -23,6 +23,20 @@
   <%= form.label_and_boolean("restricted", form.obj["override_restricted"] ? {} : {:disabled => "disabled"}) %>
   <%= form.label_and_boolean("override_restricted") %>
 
+  <% if !@top_container["rights_restricted_contents"].empty? %>
+    <div class="control-group token-list">
+         <label class="control-label"><%= I18n.t("top_container.rights_restricted_contents") %></label>
+         <div class="controls">
+             <% @top_container["rights_restricted_contents"].each do |ref| %>
+             <%= render_token :object => ref,
+                               :label => ref["display_string"],
+                                :type => ref['type'],
+                                 :uri => ref["ref"] %>
+             <% end %>
+         </div>
+    </div>
+  <% end %>
+
   <div class="subrecord-form-container">
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "container_locations"} %>
   </div>

--- a/frontend/views/top_containers/_form.html.erb
+++ b/frontend/views/top_containers/_form.html.erb
@@ -20,7 +20,8 @@
   <%= form.label_and_readonly("exported_to_ils", I18n.t("top_container.not_exported")) %>
   <%= form.hidden_input("exported_to_ils") %>
 
-  <%= form.label_and_boolean("restricted") %>
+  <%= form.label_and_boolean("restricted", form.obj["override_restricted"] ? {} : {:disabled => "disabled"}) %>
+  <%= form.label_and_boolean("override_restricted") %>
 
   <div class="subrecord-form-container">
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "container_locations"} %>

--- a/frontend/views/top_containers/show.html.erb
+++ b/frontend/views/top_containers/show.html.erb
@@ -35,6 +35,19 @@
           <%= readonly.label_and_boolean "restricted" %>
           <%= readonly.label_and_boolean "override_restricted" %>
 
+          <% if !@top_container["rights_restricted_contents"].empty? %>
+            <div class="control-group token-list">
+                <label class="control-label"><%= I18n.t("top_container.rights_restricted_contents") %></label>
+                <div class="controls">
+                    <% @top_container["rights_restricted_contents"].each do |ref| %>
+                    <%= render_token :object => ref,
+                                      :label => ref["display_string"],
+                                       :type => ref['type'],
+                                        :uri => ref["ref"] %>
+                    <% end %>
+                </div>
+            </div>
+          <% end %>
 
           <% if @top_container["container_locations"].length > 0 %>
             <hr>

--- a/frontend/views/top_containers/show.html.erb
+++ b/frontend/views/top_containers/show.html.erb
@@ -33,6 +33,7 @@
           <%= readonly.label_and_textarea "exported_to_ils", :default => I18n.t("top_container.not_exported") %>
 
           <%= readonly.label_and_boolean "restricted" %>
+          <%= readonly.label_and_boolean "override_restricted" %>
 
 
           <% if @top_container["container_locations"].length > 0 %>

--- a/migrations/012_top_container_override_restricted.rb
+++ b/migrations/012_top_container_override_restricted.rb
@@ -1,0 +1,14 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    alter_table(:top_container) do
+      add_column(:override_restricted, Integer, :default => 0)
+    end
+  end
+
+  down do
+  end
+
+end

--- a/schemas/top_container.rb
+++ b/schemas/top_container.rb
@@ -22,6 +22,30 @@
       "restricted" => {"type" => "boolean", "default" => false},
       "override_restricted" => {"type" => "boolean", "default" => false},
 
+      "rights_restricted_contents" => {
+        "readonly" => "true",
+        "type" => "array",
+        "items" => {
+          "type" => "object",
+          "subtype" => "ref",
+          "properties" => {
+            "ref" => {
+              "type" => [
+                {"type" => "JSONModel(:resource) uri"},
+                {"type" => "JSONModel(:archival_object) uri"},
+                {"type" => "JSONModel(:accession) uri"}
+              ]
+            },
+            "display_string" => {"type" => "string"},
+            "type" => {"type" => "string"},
+            "_resolved" => {
+              "type" => "object",
+              "readonly" => "true"
+            }
+          }
+        }
+      },
+
       "container_locations" => {
         "type" => "array",
         "items" => {

--- a/schemas/top_container.rb
+++ b/schemas/top_container.rb
@@ -20,6 +20,7 @@
       "exported_to_ils" => {"type" => "string", "required" => false},
 
       "restricted" => {"type" => "boolean", "default" => false},
+      "override_restricted" => {"type" => "boolean", "default" => false},
 
       "container_locations" => {
         "type" => "array",


### PR DESCRIPTION
[Delivers 85393508]
-  Works out a top container's restricted status based on whether it has any contents that have an active rights statement whose date range includes today.
-  Allows the user to override this calculated value.
-  Shows the user any contents that are rights restricted.
