### PR TITLE
Barcode Rapid Entry (take 2)

### DIFF
--- a/frontend/assets/top_containers.bulk.css
+++ b/frontend/assets/top_containers.bulk.css
@@ -33,10 +33,12 @@
     overflow: auto;
 }
 
-#bulk_operation_results .linked-records-listing {
+#bulk_operation_results .linked-records-listing,
+#bulkActionBarcodeRapidEntryModal .linked-records-listing {
     margin: 0;
     list-style-position: inside;
 }
-#bulk_operation_results .linked-records-listing.count-1 {
+#bulk_operation_results .linked-records-listing.count-1,
+#bulkActionBarcodeRapidEntryModal .linked-records-listing.count-1 {
     list-style: none;
 }

--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -279,6 +279,7 @@ BulkActionBarcodeRapidEntry.prototype.setup_form_submission = function($modal) {
     type: "POST",
     beforeSubmit: function() {
       $form.find(":submit").addClass("disabled").attr("disabled","disabled");
+      $form.find(".error").removeClass("error");
     },
     success: function(html) {
       $form.replaceWith(html);

--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -137,7 +137,7 @@ class TopContainersController < ApplicationController
   def update_barcodes
     update_uris = params[:update_uris]
     barcode_data = {}
-    update_uris.map{|uri| barcode_data[uri] = params[uri]}
+    update_uris.map{|uri| barcode_data[uri] = params[uri].blank? ? nil : params[uri]}
 
     post_uri = "#{JSONModel::HTTP.backend_url}/repositories/#{session[:repo_id]}/top_containers/bulk/barcodes"
 

--- a/frontend/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_bulk_action_templates.html.erb
@@ -69,14 +69,20 @@
     <table class="table table-striped table-bordered table-condensed table-hover">
     <thead>
       <tr>
-        <th>Top Container</th>
+        <th>Resource/Accession</th>
+        <th>Series</th>
+        <th>Container Profile</th>
+        <th>Indicator</th>
         <th>Existing Barcode</th>
         <th>New Barcode</th>
       </tr>
     </thead>
     {for container in selection}
       <tr>
-        <td>${container.display_string}</td>
+        <td>${container.row.find(".top-container-collection").html()}</td>
+        <td>${container.row.find(".top-container-series").html()}</td>
+        <td>${container.row.find(".top-container-profile").html()}</td>
+        <td>${container.row.find(".top-container-indicator").html()}</td>
         <td>${container.row.find(".top-container-barcode").text().trim()}</td>
         <td><input type="text" name="${container.uri}" value="" /><input type="hidden" name="update_uris[]" value="${container.uri}"/></td>
       </tr>

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -66,8 +66,8 @@
             </ul>
           <% end %>
         </td>
-        <td><%= Array(doc['container_profile_display_string_u_sstr']).first %></td>
-        <td><%= container_json['indicator'] %></td>
+        <td class="top-container-profile"><%= Array(doc['container_profile_display_string_u_sstr']).first %></td>
+        <td class="top-container-indicator"><%= container_json['indicator'] %></td>
         <td class="top-container-barcode"><%= container_json['barcode'] %></td>
         <td><%= Array(doc['location_display_string_u_sstr']).first %></td>
         <td><%= container_json['ils_holding_id'] %></td>


### PR DESCRIPTION
Adds some more data to the rapid entry form based on this requirement "As an archivist, when entering barcodes, I need to know the box number, associated series, and container profile type associated with that container to confirm that I am entering the proper barcode".

Also fix a bug whereby empty strings caused a uniqueness exception.  I know map all empty strings to `nil` so the barcode value is nulled. 