### PR TITLE
More info for linked records in location view

### DIFF
--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -115,7 +115,13 @@ class TopContainer < Sequel::Model(:top_container)
 
 
   def display_string
-    ["Container", "#{indicator}:", series_label, format_barcode].compact.join(" ")
+    resource = collections.first
+    resource &&= resource.title
+    container_profile = related_records(:top_container_profile)
+    container_profile &&= container_profile.name
+    container_bit = ["Container", "#{indicator}", format_barcode].compact.join(" ")
+
+    [resource, series_label, container_bit, container_profile].compact.join(", ")
   end
 
 

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -15,6 +15,19 @@ Rails.application.config.after_initialize do
 
   end
 
+
+  SearchHelper.class_eval do
+
+    alias_method :can_edit_search_result_pre_yale_container?, :can_edit_search_result?
+
+    def can_edit_search_result?(record)
+      return user_can?('manage_container', record['id']) if record['primary_type'] === "top_container"
+      can_edit_search_result_pre_yale_container?(record)
+    end
+
+  end
+
+
   # force load our JSONModels so the are registered rather than lazy initialised
   # we need this for parse_reference to work
   JSONModel(:top_container)

--- a/migrations/013_reindex_top_containers.rb
+++ b/migrations/013_reindex_top_containers.rb
@@ -1,0 +1,13 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    self[:top_container].update(:system_mtime => Time.now)
+    self[:container_profile].update(:system_mtime => Time.now)
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
[fixes #88044566]

the request was for this more elaborate display string to appear in location linked records. it made sense for this to simply replace the existing display_string. hopefully that is acceptable!

also, there was a request to see an edit button for top containers in location linked records. did this by overriding the can_edit_search_result? helper method in plugin_init.
