### PR TITLE
[Delivers #82735468] Fix rapid barcode entry 'return' key skipping inputs

### DIFF
--- a/frontend/assets/top_containers.bulk.js
+++ b/frontend/assets/top_containers.bulk.js
@@ -256,7 +256,7 @@ BulkActionBarcodeRapidEntry.prototype.setup_keyboard_handling = function($modal)
         offsetTop: 400
       });
     }).
-    on("keyup keypress",
+    on("keypress",
     function(event) {
       if (event.keyCode == 13) {
         event.stopPropagation();


### PR DESCRIPTION
Only catch 'return' on keypress event so it tabs to the next input field (rather than jump fields as two events where catching the event previously)