### PR TITLE
pad the bottom of the sub container show template if type_2 etc are blank

### DIFF
--- a/frontend/views/sub_containers/_show.html.erb
+++ b/frontend/views/sub_containers/_show.html.erb
@@ -8,6 +8,11 @@
   </div>
 </div>
 
+<% unless sub_container["type_2"] || sub_container["indicator_2"] ||
+          sub_container["type_3"] || sub_container["indicator_3"] %>
+  <br/><br/>
+<% end %>
+
 <% define_template "sub_container", jsonmodel_definition(:sub_container) do |form| %>
   <%= form.label_and_select "type_2", form.possible_options_for('type_2', true) %>
   <%= form.label_and_textfield  "indicator_2" %>


### PR DESCRIPTION
[possibly delivers #82734188]

this fixes a problem where if a subcontainer has no value for type_2, indicator_2, type_3 and indicator_3 then there is no room below the top container token for it to show its view button.

So if those fields are all blank then pad with a couple of brs :tongue: 