### PR TITLE
[Delivers #88514304] Remove scoping of top container's linker typeahead so it search entire repo

### DIFF
--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -87,8 +87,6 @@ class TopContainersController < ApplicationController
   def typeahead
     search_params = params_for_backend_search
 
-    search_params = search_params.merge(search_filter_for(params[:uri]))
-
     render :json => Search.all(session[:repo_id], search_params)
   end
 
@@ -167,24 +165,6 @@ class TopContainersController < ApplicationController
   def barcode_length_range
     check = BarcodeCheck.new(current_repo[:repo_code])
     "#{check.min}-#{check.max}"
-  end
-
-
-  def search_filter_for(uri)
-    return {} if uri.blank?
-
-    parsed = JSONModel.parse_reference(uri)
-
-    if parsed[:type] == "archival_object"
-      series_uri = JSONModel(:archival_object).find(parsed[:id]).series['ref']
-      return {
-        "filter_term[]" => [{"series_uri_u_sstr" => series_uri}.to_json]
-      }
-    end
-
-    return {
-      "filter_term[]" => [{"collection_uri_u_sstr" => uri}.to_json]
-    }
   end
 
 

--- a/frontend/views/top_containers/_linker.html.erb
+++ b/frontend/views/top_containers/_linker.html.erb
@@ -12,24 +12,6 @@
   required = true if required.nil?
 
   linkable_types = ["top_container"]
-
-  build_typeahead_url = proc {
-    record = [:"@accession", :"@archival_object", :"@resource"].map {|instvar| self.instance_variable_get(instvar)}.compact.first
-    # If a new record resource or accession, uri will be nil and the typeahead will search
-    # within the repository.
-    # If an existing accession then scope the typeahead to just this accession
-    uri = record.uri
-
-    # If the record is part of a resource collection then scope the typeahead
-    # search within the entire resource hierarchy. This will apply to all archival
-    # objects within a tree and when editing the top most resource record
-    unless record["resource"].blank?
-      uri = record["resource"]["ref"]
-    end
-
-    url_for :controller => :top_containers, :action => :typeahead, :format => :json, :uri => uri
-  }
-
 %>
 <div class="control-group <% if required %>required<% end %>">
   <label class="control-label"><%= I18n.t("top_container._singular") %></label>
@@ -41,7 +23,7 @@
              data-label_plural="<%= I18n.t("top_container._plural") %>"
              data-name="ref"
              data-path="<%= form.path %>"
-             data-url="<%= build_typeahead_url.call %>"
+             data-url="<%= url_for :controller => :top_containers, :action => :typeahead, :format => :json %>"
              data-browse-url="<%= url_for :controller => :top_containers, :action => :bulk_operations_browse %>"
              data-selected="<%= selected_json %>"
              data-multiplicity="one"


### PR DESCRIPTION
So it matches the browse behaviour.