### PR TITLE
fixed barcode range message for ranges of 1

### DIFF
--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -178,7 +178,7 @@ class TopContainersController < ApplicationController
   helper_method :barcode_length_range
   def barcode_length_range
     check = BarcodeCheck.new(current_repo[:repo_code])
-    "#{check.min}-#{check.max}"
+    check.min == check.max ? check.min.to_s : "#{check.min}-#{check.max}"
   end
 
 


### PR DESCRIPTION
[fix for #89234060]

Now displays like this:
Barcode length for this repository: 9 characters

Instead of this:
Barcode length for this repository: 9-9 characters