### PR TITLE
Replace restricted boolean with enum

### DIFF
--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -160,18 +160,19 @@ class TopContainer < Sequel::Model(:top_container)
         json['exported_to_ils'] = json['exported_to_ils'].getlocal.iso8601
       end
 
-      obj.rights_restricted_contents.each do |contents|
-        json['rights_restricted_contents'] ||= []
-        json['rights_restricted_contents'] << {
-          'ref' => contents.uri,
-          'type' => contents.class.my_jsonmodel.record_type,
-          'display_string' => find_title_for(contents)
-        }
-      end
-
-      if obj.override_restricted == 0
-        json['restricted'] = !json['rights_restricted_contents'].empty?
-      end
+### leaving this here as it may be useful when this is reimplemented
+#      obj.rights_restricted_contents.each do |contents|
+#        json['rights_restricted_contents'] ||= []
+#        json['rights_restricted_contents'] << {
+#          'ref' => contents.uri,
+#          'type' => contents.class.my_jsonmodel.record_type,
+#          'display_string' => find_title_for(contents)
+#        }
+#      end
+#
+#      if obj.override_restricted == 0
+#        json['restricted'] = !json['rights_restricted_contents'].empty?
+#      end
     end
 
     jsons

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -31,6 +31,10 @@ en:
     restricted: Restricted?
     override_restricted: Override Restricted?
     rights_restricted_contents: Rights Restricted Contents
+    legacy_restricted: Legacy Restricted?
+    legacy_restricted_none: None
+    legacy_restricted_fear: Fear
+    legacy_restricted_loathing: Loathing
     parent: Parent Container
 
     yale_container_2_type: Child Container Type

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -32,9 +32,6 @@ en:
     override_restricted: Override Restricted?
     rights_restricted_contents: Rights Restricted Contents
     legacy_restricted: Legacy Restricted?
-    legacy_restricted_none: None
-    legacy_restricted_fear: Fear
-    legacy_restricted_loathing: Loathing
     parent: Parent Container
 
     yale_container_2_type: Child Container Type

--- a/frontend/views/top_containers/_form.html.erb
+++ b/frontend/views/top_containers/_form.html.erb
@@ -20,7 +20,7 @@
   <%= form.label_and_readonly("exported_to_ils", I18n.t("top_container.not_exported")) %>
   <%= form.hidden_input("exported_to_ils") %>
 
-  <%= form.label_and_select "legacy_restricted", form.possible_options_for('legacy_restricted') %>
+  <%= form.label_and_boolean "legacy_restricted" %>
   <%# form.label_and_boolean("restricted", form.obj["override_restricted"] ? {} : {:disabled => "disabled"}) %>
   <%# form.label_and_boolean("override_restricted") %>
 

--- a/frontend/views/top_containers/_form.html.erb
+++ b/frontend/views/top_containers/_form.html.erb
@@ -20,8 +20,9 @@
   <%= form.label_and_readonly("exported_to_ils", I18n.t("top_container.not_exported")) %>
   <%= form.hidden_input("exported_to_ils") %>
 
-  <%= form.label_and_boolean("restricted", form.obj["override_restricted"] ? {} : {:disabled => "disabled"}) %>
-  <%= form.label_and_boolean("override_restricted") %>
+  <%= form.label_and_select "legacy_restricted", form.possible_options_for('legacy_restricted') %>
+  <%# form.label_and_boolean("restricted", form.obj["override_restricted"] ? {} : {:disabled => "disabled"}) %>
+  <%# form.label_and_boolean("override_restricted") %>
 
   <% if !@top_container["rights_restricted_contents"].empty? %>
     <div class="control-group token-list">

--- a/frontend/views/top_containers/show.html.erb
+++ b/frontend/views/top_containers/show.html.erb
@@ -32,8 +32,9 @@
           <%= readonly.label_and_textarea "ils_item_id" %>
           <%= readonly.label_and_textarea "exported_to_ils", :default => I18n.t("top_container.not_exported") %>
 
-          <%= readonly.label_and_boolean "restricted" %>
-          <%= readonly.label_and_boolean "override_restricted" %>
+          <%= readonly.label_and_select "legacy_restricted", form.possible_options_for('legacy_restricted') %>
+          <%# readonly.label_and_boolean "restricted" %>
+          <%# readonly.label_and_boolean "override_restricted" %>
 
           <% if !@top_container["rights_restricted_contents"].empty? %>
             <div class="control-group token-list">

--- a/frontend/views/top_containers/show.html.erb
+++ b/frontend/views/top_containers/show.html.erb
@@ -32,7 +32,7 @@
           <%= readonly.label_and_textarea "ils_item_id" %>
           <%= readonly.label_and_textarea "exported_to_ils", :default => I18n.t("top_container.not_exported") %>
 
-          <%= readonly.label_and_select "legacy_restricted", form.possible_options_for('legacy_restricted') %>
+          <%= readonly.label_and_boolean "legacy_restricted" %>
           <%# readonly.label_and_boolean "restricted" %>
           <%# readonly.label_and_boolean "override_restricted" %>
 

--- a/migrations/015_top_container_legacy_restricted.rb
+++ b/migrations/015_top_container_legacy_restricted.rb
@@ -1,0 +1,14 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    alter_table(:top_container) do
+      add_column(:legacy_restricted, String, :default => 'none')
+    end
+  end
+
+  down do
+  end
+
+end

--- a/migrations/015_top_container_legacy_restricted.rb
+++ b/migrations/015_top_container_legacy_restricted.rb
@@ -4,7 +4,7 @@ Sequel.migration do
 
   up do
     alter_table(:top_container) do
-      add_column(:legacy_restricted, String, :default => 'none')
+      add_column(:legacy_restricted, Integer, :default => 0)
     end
   end
 

--- a/schemas/top_container.rb
+++ b/schemas/top_container.rb
@@ -20,6 +20,7 @@
       "ils_item_id" => {"type" => "string", "maxLength" => 255, "required" => false},
       "exported_to_ils" => {"type" => "string", "required" => false},
 
+      "legacy_restricted" => {"type" => "string", "enum" => ["none", "fear", "loathing"], "ifmissing" => "error"},
       "restricted" => {"type" => "boolean", "default" => false},
       "override_restricted" => {"type" => "boolean", "default" => false},
 

--- a/schemas/top_container.rb
+++ b/schemas/top_container.rb
@@ -20,7 +20,7 @@
       "ils_item_id" => {"type" => "string", "maxLength" => 255, "required" => false},
       "exported_to_ils" => {"type" => "string", "required" => false},
 
-      "legacy_restricted" => {"type" => "string", "enum" => ["none", "fear", "loathing"], "ifmissing" => "error"},
+      "legacy_restricted" => {"type" => "boolean", "default" => false},
       "restricted" => {"type" => "boolean", "default" => false},
       "override_restricted" => {"type" => "boolean", "default" => false},
 


### PR DESCRIPTION
[delivers #89016938]

the requirement changed - now legacy_restricted should be a boolean.

I left all of the old restricted stuff in there as it will probably be reused in some form when we redo this. Just commented out the UI bits and the one operation that is a bit expensive. Perhaps it's better to fully back this stuff out. Let me know if that is the preference.
