### PR TITLE
remove location_uris from index for aos, resources and accessions

### DIFF
--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -54,6 +54,14 @@ class CommonIndexer
         doc['exported_u_sbool'] = record['record'].has_key?('exported_to_ils')
       end
     }
+
+
+    indexer.add_document_prepare_hook {|doc, record|
+      # we no longer want the contents of containers to be indexed at the container's location
+      if ['resource', 'archival_object', 'accession'].include?(doc['primary_type'])
+        doc.delete('location_uris')
+      end
+    }
   end
 
   @@record_types << :container_profile

--- a/migrations/016_reindex_archival_objects_and_friends.rb
+++ b/migrations/016_reindex_archival_objects_and_friends.rb
@@ -1,0 +1,15 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    now = Time.now
+    self[:resource].update(:system_mtime => now)
+    self[:archival_object].update(:system_mtime => now)
+    self[:accession].update(:system_mtime => now)
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
[fixes #88044566] ... yet again

This seemed like the cleanest way to ensure the aos, resources and accessions don't appear in the linked records section of the location view. Not sure how kosher it is.
