### PR TITLE
[Delivers #89453818] fix container summary in tree view

### DIFF
--- a/backend/model/resource_trees_ext.rb
+++ b/backend/model/resource_trees_ext.rb
@@ -1,0 +1,32 @@
+module ResourceTrees
+  alias_method :set_node_instances_pre_container_management, :set_node_instances
+  def set_node_instances(node, properties)
+    if node.instance.length > 0
+      properties[:instance_types] = node.instance.map {|instance|
+        instance.values[:instance_type]
+      }
+
+      properties[:containers] = node.instance.collect {|instance|
+        instance.sub_container
+      }.flatten.compact.map {|sub_container|
+        properties = {}
+
+        top_container = sub_container.related_records(:top_container_link)
+
+        if (top_container)
+          properties["type_1"] = "Container #{top_container.indicator}"
+          properties["indicator_1"] = "[#{top_container.barcode}]"
+        end
+
+        properties["type_2"] = BackendEnumSource.value_for_id("container_type",
+                                                              sub_container.type_2_id)
+        properties["indicator_2"] = sub_container.indicator_2
+        properties["type_3"] = BackendEnumSource.value_for_id("container_type",
+                                                              sub_container.type_3_id)
+        properties["indicator_3"] = sub_container.indicator_3
+
+        properties
+      }
+    end
+  end
+end

--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -22,7 +22,6 @@ ASModel.all_models.each do |model|
   end
 end
 
-
 if AppConfig.has_key?(:migrate_to_container_management) && AppConfig[:migrate_to_container_management]
 
   Log.info("Migrating existing containers to the new container model...")

--- a/frontend/views/archival_objects/_edit_inline.html.erb
+++ b/frontend/views/archival_objects/_edit_inline.html.erb
@@ -1,0 +1,52 @@
+<%= form_for @archival_object, :as => "archival_object", :url => {:action => :update, :id => @archival_object.id}, :html => {:class => 'form-horizontal aspace-record-form', :id => 'archival_object_form'}.merge(update_monitor_params(@archival_object)) do |f| %>
+  <%= form_context :archival_object, @archival_object do |form| %>
+    <div class="row-fluid">
+      <div class="span3">
+        <%= render_aspace_partial :partial => "sidebar" %>
+      </div>
+      <div class="span9">
+        <%= render_aspace_partial :partial => "toolbar" %>
+        <div class="record-pane">
+          <%= render_aspace_partial :partial => "archival_objects/form_container", :locals => {:form => form} %>
+          <div class="form-actions">
+            <button type="submit" class="btn btn-primary"><%= I18n.t("archival_object._frontend.action.save") %></button>
+            <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel" %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <% if @refresh_tree_node
+        node_data = {
+          'id' => @archival_object.id,
+          'uri' => @archival_object.uri,
+          'title' => @archival_object.display_string,
+          'level' => @archival_object.level==='otherlevel' ? @archival_object.other_level : I18n.t("enumerations.archival_record_level.#{@archival_object.level}", :default => @archival_object.level),
+          'jsonmodel_type' => @archival_object.jsonmodel_type,
+          'node_type' => @archival_object.jsonmodel_type,
+          'instance_types' => @archival_object.instances.map{|instance| I18n.t("enumerations.instance_instance_type.#{instance['instance_type']}", :default => instance['instance_type'])},
+          'containers' => @archival_object.to_hash["instances"].map{|instance| instance["sub_container"]}.compact.map {|sub_container|
+            properties = {}
+            if sub_container["top_container"]
+              top_container = sub_container["top_container"]["_resolved"]
+              # if _resolved comes from search result, then need to parse JSON
+              if top_container["json"]
+                top_container = ASUtils.json_parse(top_container["json"])
+              end
+              properties["type_1"] = "Container #{top_container["indicator"]}"
+              properties["indicator_1"] = "[#{top_container["barcode"]}]"
+            end
+            properties["type_2"] = I18n.t("enumerations.container_type.#{sub_container["type_2"]}", :default => sub_container["type_2"])
+            properties["indicator_2"] =sub_container["indicator_2"]
+            properties["type_3"] = I18n.t("enumerations.container_type.#{sub_container["type_3"]}", :default => sub_container["type_3"])
+            properties["indicator_3"] =sub_container["indicator_3"]
+            properties
+          },
+          'replace_new_node' => controller.action_name === 'create'
+        }
+    %>
+      <script>
+        AS.refreshTreeNode(<%= node_data.to_json.html_safe %>);
+      </script>
+    <% end %>
+  <% end %>
+<% end %>

--- a/frontend/views/resources/_edit_inline.html.erb
+++ b/frontend/views/resources/_edit_inline.html.erb
@@ -1,0 +1,53 @@
+<%= form_for @resource, :as => "resource", :url => {:action => :update, :id => @resource.id}, :html => {:class => 'form-horizontal aspace-record-form', :id => "resource_form"}.merge(update_monitor_params(@resource)) do |f| %>
+  <%= form_context :resource, @resource do |form| %>
+    <div class="row-fluid">
+      <div class="span3">
+        <%= render_aspace_partial :partial => "resources/sidebar" %>
+      </div>
+      <div class="span9">
+        <%= render_aspace_partial :partial => "toolbar" %>
+        <div class="record-pane">
+           <%= render_aspace_partial :partial => "resources/form_container", :locals => {:form => form} %>
+           <div class="form-actions">
+             <button type="submit" class="btn btn-primary"><%= I18n.t("resource._frontend.action.save") %></button>
+              <%= link_to I18n.t("actions.cancel"), :back, :class => "btn btn-cancel" %>
+           </div>
+         </div>
+      </div>
+    </div>
+
+    <% if @refresh_tree_node
+         node_data = {
+           'id' => @resource.id,
+           'uri' => @resource.uri,
+           'title' => @resource.title,
+           'level' => @resource.level==='otherlevel' ? @resource.other_level : I18n.t("enumerations.archival_record_level.#{@resource.level}", :default => @resource.level),
+           'jsonmodel_type' => @resource.jsonmodel_type,
+           'node_type' => @resource.jsonmodel_type,
+           'instance_types' => @resource.instances.map{|instance| I18n.t("enumerations.instance_instance_type.#{instance['instance_type']}", :default => instance['instance_type'])},
+           'containers' => @resource.to_hash["instances"].map{|instance| instance["sub_container"]}.compact.map {|sub_container|
+             properties = {}
+             if sub_container["top_container"]
+               top_container = sub_container["top_container"]["_resolved"]
+               # if _resolved comes from search result, then need to parse JSON
+               if top_container["json"]
+                 top_container = ASUtils.json_parse(top_container["json"])
+               end
+               properties["type_1"] = "Container #{top_container["indicator"]}"
+               properties["indicator_1"] = "[#{top_container["barcode"]}]"
+             end
+             properties["type_2"] = I18n.t("enumerations.container_type.#{sub_container["type_2"]}", :default => sub_container["type_2"])
+             properties["indicator_2"] =sub_container["indicator_2"]
+             properties["type_3"] = I18n.t("enumerations.container_type.#{sub_container["type_3"]}", :default => sub_container["type_3"])
+             properties["indicator_3"] =sub_container["indicator_3"]
+             properties
+           },
+           'replace_new_node' => false
+         }
+    %>
+      <script>
+        AS.refreshTreeNode(<%= node_data.to_json.html_safe %>);
+      </script>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
This patch overrides the ResourceTrees#set_node_instances to aggregate the sub container/top container data back on the tree node. And also override the _edit_inline.html.erb templates for Resource and Archival Object so they aggregate the new sub_container/top_container data correctly also.  

It'd be nice if this container data wasn't aggregated in multiple places!  But looking at the jstree/tree.js it's a bit of a mine field.  If we had some more time I think we could patch the core code to refresh the node completely via an AJAX call once the record had been saved so we could avoid building a fake node json in the edit_inline templates.  But this feels like days coding/testing.  :tired_face: 

And I know.. this solution is a little brute force.  I think we can sleep well knowing that having overrides will make the merge into the core code base easier for the person doing the merging. :relieved: 