### PR TITLE
[Delivers #89711490] Fix empty brackets in the tree's container summary 

### DIFF
--- a/backend/model/resource_trees_ext.rb
+++ b/backend/model/resource_trees_ext.rb
@@ -14,8 +14,11 @@ module ResourceTrees
         top_container = sub_container.related_records(:top_container_link)
 
         if (top_container)
-          properties["type_1"] = "Container #{top_container.indicator}"
-          properties["indicator_1"] = "[#{top_container.barcode}]"
+          properties["type_1"] = "Container"
+          properties["indicator_1"] = top_container.indicator
+          if top_container.barcode
+            properties["indicator_1"] += " [#{top_container.barcode}]"
+          end
         end
 
         properties["type_2"] = BackendEnumSource.value_for_id("container_type",

--- a/frontend/views/archival_objects/_edit_inline.html.erb
+++ b/frontend/views/archival_objects/_edit_inline.html.erb
@@ -32,8 +32,11 @@
               if top_container["json"]
                 top_container = ASUtils.json_parse(top_container["json"])
               end
-              properties["type_1"] = "Container #{top_container["indicator"]}"
-              properties["indicator_1"] = "[#{top_container["barcode"]}]"
+              properties["type_1"] = "Container"
+              properties["indicator_1"] = top_container["indicator"]
+              if top_container["barcode"]
+                properties["indicator_1"] += " [#{top_container["barcode"]}]"
+              end
             end
             properties["type_2"] = I18n.t("enumerations.container_type.#{sub_container["type_2"]}", :default => sub_container["type_2"])
             properties["indicator_2"] =sub_container["indicator_2"]

--- a/frontend/views/resources/_edit_inline.html.erb
+++ b/frontend/views/resources/_edit_inline.html.erb
@@ -33,8 +33,11 @@
                if top_container["json"]
                  top_container = ASUtils.json_parse(top_container["json"])
                end
-               properties["type_1"] = "Container #{top_container["indicator"]}"
-               properties["indicator_1"] = "[#{top_container["barcode"]}]"
+               properties["type_1"] = "Container"
+               properties["indicator_1"] = top_container["indicator"]
+               if top_container["barcode"]
+                 properties["indicator_1"] += " [#{top_container["barcode"]}]"
+               end
              end
              properties["type_2"] = I18n.t("enumerations.container_type.#{sub_container["type_2"]}", :default => sub_container["type_2"])
              properties["indicator_2"] =sub_container["indicator_2"]


### PR DESCRIPTION
.. when there is no barcode.  Reformat the string to optionally display the barcode if it is present and look like this 'Container: <indicator> [<barcode>]'.