### PR TITLE
added a suppressed column to the rlshp tables

### DIFF
--- a/migrations/018_add_suppressed_to_rlshp_tables.rb
+++ b/migrations/018_add_suppressed_to_rlshp_tables.rb
@@ -1,0 +1,17 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    [:top_container_link_rlshp, :top_container_housed_at_rlshp,
+     :top_container_profile_rlshp].each do |table|
+      alter_table(:top_container_link_rlshp) do
+        add_column(:suppressed, Integer, :null => false, :default => 0)
+      end
+    end
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
[kind of a fix for #89734308]

Anything with an instance was blowing up in public. The reason was the relationship mixin wanting to call suppressed on the relationship classes. So I added it and now it's happy.

I guess we never saw this because we're always admin ;)
