### PR TITLE
add support for finding empty top containers

### DIFF
--- a/backend/model/mixins/reindex_top_containers.rb
+++ b/backend/model/mixins/reindex_top_containers.rb
@@ -1,6 +1,6 @@
 module ReindexTopContainers
 
-  def reindex_top_containers
+  def reindex_top_containers(extra_ids = [])
     # Find any relationships between a top container and any instance within the current tree.
     root_record = self.root_record_id ? self.class.root_model[self.root_record_id] : self.topmost_archival_object
 
@@ -8,9 +8,10 @@ module ReindexTopContainers
     top_container_link_rlshp = SubContainer.find_relationship(:top_container_link)
     relationship_ids = tree_object_graph.ids_for(top_container_link_rlshp)
 
-    # Update the mtimes of each top containers
+    # Update the mtimes of each top container
     DB.open do |db|
-      top_container_ids = db[:top_container_link_rlshp].filter(:id => relationship_ids).select(:top_container_id)
+      top_container_ids = db[:top_container_link_rlshp].filter(:id => relationship_ids).map(:top_container_id)
+      top_container_ids.concat(extra_ids)
       TopContainer.filter(:id => top_container_ids).update(:system_mtime => Time.now)
     end
   end
@@ -29,9 +30,14 @@ module ReindexTopContainers
 
 
   def update_from_json(json, opts = {}, apply_nested_records = true)
+    # we need to reindex top containers for instances about to be zapped
+    # so remember the top containers we currently link to ...
+    top_container_ids = instance.map {|instance| instance.sub_container.first.related_records(:top_container_link).id }
+
     result = super
 
-    reindex_top_containers unless opts[:skip_reindex_top_containers]
+    # ... and pass them in as extras
+    reindex_top_containers(top_container_ids) unless opts[:skip_reindex_top_containers]
 
     result
   end

--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -204,6 +204,9 @@ class TopContainersController < ApplicationController
     unless params['exported'].blank?
       filters.push({'exported_u_sbool' => (params['exported'] == "yes" ? true : false)}.to_json)
     end
+    unless params['empty'].blank?
+      filters.push({'empty_u_sbool' => (params['empty'] == "yes" ? true : false)}.to_json)
+    end
 
     if filters.empty? && params['q'].blank?
       raise MissingFilterException.new

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -73,6 +73,9 @@ en:
         keyword_criteria: Keyword
         exported_to_ils_true: "Yes"
         exported_to_ils_false: "No"
+        empty: Empty
+        empty_true: "Yes"
+        empty_false: "No"
         search: Search
         update_ils_holding_ids: Update ILS Holding IDs
         update_ils_holding_ids_help: Enter a value for ILS Holding ID for all selected containers.

--- a/frontend/views/top_containers/bulk_operations/_search_criteria.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_search_criteria.html.erb
@@ -37,6 +37,12 @@
           </div>
         </div>
         <div class="control-group">
+          <label class="control-label" for="location"><%= I18n.t("top_container._frontend.bulk_operations.empty") %></label>
+          <div class="controls">
+            <select name="empty"><option></option><option value="yes"><%= I18n.t("top_container._frontend.bulk_operations.empty_true") %></option><option value="no"><%= I18n.t("top_container._frontend.bulk_operations.empty_false") %></option></select>
+          </div>
+        </div>
+        <div class="control-group">
           <div class="controls">
             <%= submit_tag I18n.t("top_container._frontend.bulk_operations.search"), :class => "btn btn-primary pull-right" %>
           </div>

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -52,6 +52,7 @@ class CommonIndexer
           end
         end
         doc['exported_u_sbool'] = record['record'].has_key?('exported_to_ils')
+        doc['empty_u_sbool'] = record['record']['collection'].empty?
       end
     }
 

--- a/migrations/019_reindex_top_containers.rb
+++ b/migrations/019_reindex_top_containers.rb
@@ -1,0 +1,13 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    self[:top_container].update(:system_mtime => Time.now)
+    self[:container_profile].update(:system_mtime => Time.now)
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
[fixes #84087370]

We need a way of deleting empty top containers. This achieves that by adding a filter to the top container search form for empty containers. It is then possible to delete them via the delete bulk operation.
