### PR TITLE
Sort the typeahead dropdown by the top container's indicator

### DIFF
--- a/frontend/controllers/top_containers_controller.rb
+++ b/frontend/controllers/top_containers_controller.rb
@@ -88,6 +88,7 @@ class TopContainersController < ApplicationController
     search_params = params_for_backend_search
 
     search_params = search_params.merge(search_filter_for(params[:uri]))
+    search_params = search_params.merge("sort" => "typeahead_sort_key_u_sort asc")
 
     render :json => Search.all(session[:repo_id], search_params)
   end

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -53,6 +53,8 @@ class CommonIndexer
         end
         doc['exported_u_sbool'] = record['record'].has_key?('exported_to_ils')
         doc['empty_u_sbool'] = record['record']['collection'].empty?
+
+        doc['typeahead_sort_key_u_sort'] = record['record']['indicator'].to_s.rjust(255, '#')
       end
     }
 


### PR DESCRIPTION
Padded a sort field to 255 places to sort correctly by numbers where
they're present.