### PR TITLE
changed label for empty filter

### DIFF
--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -73,7 +73,7 @@ en:
         keyword_criteria: Keyword
         exported_to_ils_true: "Yes"
         exported_to_ils_false: "No"
-        empty: Empty
+        empty: Unassociated containers
         empty_true: "Yes"
         empty_false: "No"
         search: Search


### PR DESCRIPTION
[requested for #84087370]

just changes the label for the empty filter to "Unassociated containers"

... probably should have just committed this to master - never mind.