### PR TITLE
Introduce a repository scoped permission for container profiles

### DIFF
--- a/backend/controllers/container_profile.rb
+++ b/backend/controllers/container_profile.rb
@@ -4,7 +4,7 @@ class ArchivesSpaceService < Sinatra::Base
     .description("Update a Container Profile")
     .params(["id", :id],
             ["container_profile", JSONModel(:container_profile), "The updated record", :body => true])
-    .permissions([:manage_container_profile_record])
+    .permissions([:update_container_profile_record])
     .returns([200, :updated]) \
   do
     handle_update(ContainerProfile, params[:id], params[:container_profile])
@@ -14,7 +14,7 @@ class ArchivesSpaceService < Sinatra::Base
   Endpoint.post('/container_profiles')
     .description("Create a Container_Profile")
     .params(["container_profile", JSONModel(:container_profile), "The record to create", :body => true])
-    .permissions([:manage_container_profile_record])
+    .permissions([:update_container_profile_record])
     .returns([200, :created]) \
   do
     handle_create(ContainerProfile, params[:container_profile])
@@ -48,7 +48,7 @@ class ArchivesSpaceService < Sinatra::Base
   Endpoint.delete('/container_profiles/:id')
     .description("Delete an Container Profile")
     .params(["id", :id])
-    .permissions([:manage_container_profile_record])
+    .permissions([:update_container_profile_record])
     .returns([200, :deleted]) \
   do
     handle_delete(ContainerProfile, params[:id])

--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -3,8 +3,13 @@ Permission.define("manage_container",
                   :level => "repository")
 
 Permission.define("manage_container_profile_record",
-				  "The ability to create/update/delete container profile records",
-				  :level => "global")
+                  "The ability to create, modify and delete a container profile record",
+                  :level => "repository")
+
+Permission.define("update_container_profile_record",
+                  "The ability to create/update/delete container profile records",
+                  :implied_by => 'manage_container_profile_record',
+                  :level => "global")
 
 require_relative "../yale_container_init"
 

--- a/frontend/controllers/container_profiles_controller.rb
+++ b/frontend/controllers/container_profiles_controller.rb
@@ -1,6 +1,6 @@
 class ContainerProfilesController < ApplicationController
 
-  set_access_control  "manage_container_profile_record" => [:new, :index, :edit, :create, :update, :show, :delete]
+  set_access_control  "update_container_profile_record" => [:new, :index, :edit, :create, :update, :show, :delete]
 
   FACETS = ["container_profile_width_u_sstr", "container_profile_height_u_sstr", "container_profile_depth_u_sstr", "container_profile_dimension_units_u_sstr"]
 

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -132,3 +132,8 @@ en:
       container_profile_dimension_units_u_sstr: Dimension Units
     help:
       row_selection: Click a row to select it for bulk operations. Hold alt while clicking a checkbox to select, or unselect, multple previous rows.
+
+  group:
+    permission_types:
+      manage_container: create/update/delete/bulk update top container records
+      manage_container_profile_record: create/update/delete container profile records

--- a/frontend/views/container_profiles/_toolbar.html.erb
+++ b/frontend/views/container_profiles/_toolbar.html.erb
@@ -1,4 +1,4 @@
-<% if user_can?('manage_container_profile_record') %>
+<% if user_can?('update_container_profile_record') %>
   <div class="row-fluid">
     <div class="span12">
       <div class="record-toolbar">

--- a/frontend/views/top_containers/_toolbar.html.erb
+++ b/frontend/views/top_containers/_toolbar.html.erb
@@ -1,4 +1,4 @@
-<% if user_can?('manage_container_profile_record') %>
+<% if user_can?('manage_container') %>
   <div class="row-fluid">
     <div class="span12">
       <div class="record-toolbar">

--- a/migrations/022_rename_container_profile_permission.rb
+++ b/migrations/022_rename_container_profile_permission.rb
@@ -1,0 +1,13 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    # set this permission to be repository scoped as there in new derived global permission
+    self[:permission].filter(:permission_code => "manage_container_profile_record").update(:level => "repository")
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
This new permission is derived from the global permission for managing container profiles and allows the admin to assign it to groups etc.