### PR TITLE
Compatibility rule change: If we can't find a matching top container in ...

### DIFF
--- a/backend/lib/aspace_json_to_yale_container_mapper.rb
+++ b/backend/lib/aspace_json_to_yale_container_mapper.rb
@@ -190,12 +190,8 @@ class AspaceJsonToYaleContainerMapper
       # trying to find a more specific match in the series.
       within_resource = try_matching_indicator_within_resource(container)
 
-      if within_resource
-        if (within_series = try_matching_indicator_within_series(container))
-          return within_series
-        else
-          return within_resource
-        end
+      if within_resource && (within_series = try_matching_indicator_within_series(container))
+        return within_series
       end
     end
 

--- a/backend/spec/model_compatibility_spec.rb
+++ b/backend/spec/model_compatibility_spec.rb
@@ -146,11 +146,13 @@ describe 'Yale Container compatibility' do
 
 
 
-    it "finds an existing top container linked within the same resource if it can't find one in the series" do
+    it "creates a new top container if it can't find one in the series (even if there's one in the resource!)" do
       container = TopContainer.create_from_json(JSONModel(:top_container).from_hash('indicator' => '1234'))
 
       # child links to our top container
       (resource, grandparent, parent, child) = create_tree(container)
+
+      old_count = TopContainer.all.count
 
       # create a new archival object under grandparent with an instance with the same indicator
       new_ao = create(:json_archival_object,
@@ -162,7 +164,10 @@ describe 'Yale Container compatibility' do
                                                                      })])
 
       # and it's magically linked up with the right container (from the different series)
-      ArchivalObject.to_jsonmodel(new_ao.id)['instances'].first['sub_container']['top_container']['ref'].should eq(container.uri)
+      ArchivalObject.to_jsonmodel(new_ao.id)['instances'].first['sub_container']['top_container']['ref'].should_not eq(container.uri)
+
+      # created a top container
+      TopContainer.all.count.should be > (old_count)
     end
 
 


### PR DESCRIPTION
...the current series, don't bother looking in the resource.