### PR TITLE
[Delivers #89918068] show linked records on top container view

### DIFF
--- a/frontend/assets/top_containers.show.js
+++ b/frontend/assets/top_containers.show.js
@@ -1,0 +1,1 @@
+//= require embedded_search

--- a/frontend/views/top_containers/show.html.erb
+++ b/frontend/views/top_containers/show.html.erb
@@ -57,6 +57,8 @@
             </section>
           <% end %>
 
+          <%= render_aspace_partial :partial => "search/embedded", :locals => {:record => @top_container, :filter_term => {"top_container_uri_u_sstr" => @top_container.uri}.to_json, :heading_text => I18n.t("location._frontend.section.search_embedded")} %>
+
           <hr>
           <%= display_audit_info(@top_container) %>
         <% end %>
@@ -66,3 +68,5 @@
     </div>
   </div>
 </div>
+
+<script src="<%= "#{AppConfig[:frontend_prefix]}assets/top_containers.show.js" %>"></script>

--- a/indexer/indexer.rb
+++ b/indexer/indexer.rb
@@ -53,9 +53,16 @@ class CommonIndexer
 
 
     indexer.add_document_prepare_hook {|doc, record|
-      # we no longer want the contents of containers to be indexed at the container's location
       if ['resource', 'archival_object', 'accession'].include?(doc['primary_type'])
+        # we no longer want the contents of containers to be indexed at the container's location
         doc.delete('location_uris')
+
+        # index the top_container's linked via a sub_container
+        ASUtils.wrap(record['record']['instances']).each{|instance|
+          if instance['sub_container'] && instance['sub_container']['top_container']
+            doc['top_container_uri_u_sstr'] = instance['sub_container']['top_container']['ref']
+          end
+        }
       end
     }
   end

--- a/migrations/023_reindex_records_linked_to_top_containers.rb
+++ b/migrations/023_reindex_records_linked_to_top_containers.rb
@@ -1,0 +1,15 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    now = Time.now
+    self[:resource].update(:system_mtime => now)
+    self[:archival_object].update(:system_mtime => now)
+    self[:accession].update(:system_mtime => now)
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
Index any linked top_container uris against the records they link to and then show the embedded search on the readonly top container show template.

Note: after merge there may be a migration conflict with other PRs???