### PR TITLE
Backout old restriction implementation

### DIFF
--- a/backend/model/top_container.rb
+++ b/backend/model/top_container.rb
@@ -162,28 +162,9 @@ class TopContainer < Sequel::Model(:top_container)
       if json['exported_to_ils']
         json['exported_to_ils'] = json['exported_to_ils'].getlocal.iso8601
       end
-
-### leaving this here as it may be useful when this is reimplemented
-#      obj.rights_restricted_contents.each do |contents|
-#        json['rights_restricted_contents'] ||= []
-#        json['rights_restricted_contents'] << {
-#          'ref' => contents.uri,
-#          'type' => contents.class.my_jsonmodel.record_type,
-#          'display_string' => find_title_for(contents)
-#        }
-#      end
-#
-#      if obj.override_restricted == 0
-#        json['restricted'] = !json['rights_restricted_contents'].empty?
-#      end
     end
 
     jsons
-  end
-
-
-  def rights_restricted_contents
-    linked_archival_records.select {|ao| ao.restricted_by_rights?}.uniq(&:uri)
   end
 
 

--- a/frontend/assets/top_containers.crud.js
+++ b/frontend/assets/top_containers.crud.js
@@ -1,16 +1,1 @@
 //= require form
-
-$(function () {
-	var init = function () {
-	    $('#top_container_override_restricted_').on('click', function (event) {
-		    event.stopPropagation();
-		    if ($(this).is(":checked")) {
-			$('#top_container_restricted_').removeAttr("disabled");
-		    } else {
-			$('#top_container_restricted_').attr("disabled", "disabled");;
-		    }
-		});
-	};
-
-	init();
-    });

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -29,9 +29,6 @@ en:
     ils_item_id: ILS Item ID
     exported_to_ils: Exported to ILS
     not_exported: Not exported
-    restricted: Restricted?
-    override_restricted: Override Restricted?
-    rights_restricted_contents: Rights Restricted Contents
     legacy_restricted: Legacy Restricted?
     parent: Parent Container
 

--- a/frontend/views/top_containers/_form.html.erb
+++ b/frontend/views/top_containers/_form.html.erb
@@ -21,22 +21,6 @@
   <%= form.hidden_input("exported_to_ils") %>
 
   <%= form.label_and_boolean "legacy_restricted" %>
-  <%# form.label_and_boolean("restricted", form.obj["override_restricted"] ? {} : {:disabled => "disabled"}) %>
-  <%# form.label_and_boolean("override_restricted") %>
-
-  <% if !@top_container["rights_restricted_contents"].empty? %>
-    <div class="control-group token-list">
-         <label class="control-label"><%= I18n.t("top_container.rights_restricted_contents") %></label>
-         <div class="controls">
-             <% @top_container["rights_restricted_contents"].each do |ref| %>
-             <%= render_token :object => ref,
-                               :label => ref["display_string"],
-                                :type => ref['type'],
-                                 :uri => ref["ref"] %>
-             <% end %>
-         </div>
-    </div>
-  <% end %>
 
   <div class="subrecord-form-container">
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "container_locations"} %>

--- a/frontend/views/top_containers/bulk_operations/_results.html.erb
+++ b/frontend/views/top_containers/bulk_operations/_results.html.erb
@@ -32,7 +32,7 @@
       <th><%= I18n.t("top_container._frontend.bulk_operations.current_location") %></th>
       <th><%= I18n.t("top_container.ils_holding_id") %></th>
       <th><%= I18n.t("top_container.ils_item_id") %></th>
-      <th><%= I18n.t("top_container.restricted") %></th>
+      <th><%= I18n.t("top_container.legacy_restricted") %></th>
       <th><%= I18n.t("top_container.exported_to_ils") %></th>
       <% if show_edit_actions %><th><!-- Actions --></th><% end %>
     </tr>
@@ -72,7 +72,7 @@
         <td><%= Array(doc['location_display_string_u_sstr']).first %></td>
         <td><%= container_json['ils_holding_id'] %></td>
         <td><%= container_json['ils_item_id'] %></td>
-        <td><%= I18n.t("boolean.#{container_json['restricted']}") %></td>
+        <td><%= I18n.t("boolean.#{container_json['legacy_restricted']}") %></td>
         <% if container_json['exported_to_ils'].blank? %>
           <td><%= I18n.t("top_container.not_exported") %></td>
         <% else %>

--- a/migrations/027_backout_old_rights_implementation.rb
+++ b/migrations/027_backout_old_rights_implementation.rb
@@ -1,0 +1,15 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    alter_table(:top_container) do
+      drop_column :override_restricted
+      drop_column :restricted
+    end
+  end
+
+  down do
+  end
+
+end

--- a/schemas/top_container.rb
+++ b/schemas/top_container.rb
@@ -28,32 +28,6 @@
       },
 
       "legacy_restricted" => {"type" => "boolean", "default" => false},
-      "restricted" => {"type" => "boolean", "default" => false},
-      "override_restricted" => {"type" => "boolean", "default" => false},
-
-      "rights_restricted_contents" => {
-        "readonly" => "true",
-        "type" => "array",
-        "items" => {
-          "type" => "object",
-          "subtype" => "ref",
-          "properties" => {
-            "ref" => {
-              "type" => [
-                {"type" => "JSONModel(:resource) uri"},
-                {"type" => "JSONModel(:archival_object) uri"},
-                {"type" => "JSONModel(:accession) uri"}
-              ]
-            },
-            "display_string" => {"type" => "string"},
-            "type" => {"type" => "string"},
-            "_resolved" => {
-              "type" => "object",
-              "readonly" => "true"
-            }
-          }
-        }
-      },
 
       "container_locations" => {
         "type" => "array",


### PR DESCRIPTION
Including top_container fields 'restricted', 'override_restricted' and 'rights_restricted_contents'.

On the top container bulk operations listing, I've replaced the 'Restricted' column with 'Legacy Restricted' as we don't currently index the calculated active restrictions.  These active restrictions are calculated upon sequel_to_json on the top container every time it is read -- while we could index it, we would need to ensure the linked records cause the top containers to reindex correctly when updates/deletes/moves/transfers came in.