### PR TITLE
[Delivers #89470628] Don't allow editing of the legacy_restricted field 

### DIFF
--- a/frontend/views/top_containers/_form.html.erb
+++ b/frontend/views/top_containers/_form.html.erb
@@ -20,7 +20,8 @@
   <%= form.label_and_readonly("exported_to_ils", I18n.t("top_container.not_exported")) %>
   <%= form.hidden_input("exported_to_ils") %>
 
-  <%= form.label_and_boolean "legacy_restricted" %>
+  <%= form.label_with_field "legacy_restricted", I18n.t("boolean.#{form.obj["legacy_restricted"].to_s}"), :controls_class => "label-only" %>
+  <%= form.hidden_input "legacy_restricted", form.obj["legacy_restricted"] ? 1 : 0 %>
 
   <div class="subrecord-form-container">
     <%= render_aspace_partial :partial => "shared/subrecord_form", :locals => {:form => form, :name => "container_locations"} %>


### PR DESCRIPTION
... in the top container form but retain the value by including it as a hidden input.

This complements Mark's migration mapping to bring across the legacy userdefinedbool for this field.