### PR TITLE
rejig the ReindexTopContainers mixin for use by accessions and resources

### DIFF
--- a/backend/model/accession_ext.rb
+++ b/backend/model/accession_ext.rb
@@ -1,0 +1,1 @@
+Accession.include(ReindexTopContainers)

--- a/backend/model/mixins/reindex_top_containers.rb
+++ b/backend/model/mixins/reindex_top_containers.rb
@@ -2,8 +2,11 @@ module ReindexTopContainers
 
   def reindex_top_containers(extra_ids = [])
     # Find any relationships between a top container and any instance within the current tree.
-    root_record = self.root_record_id ? self.class.root_model[self.root_record_id] : self.topmost_archival_object
-
+    root_record = if self.class == ArchivalObject
+                    self.root_record_id ? self.class.root_model[self.root_record_id] : self.topmost_archival_object
+                  else
+                    self
+                  end
     tree_object_graph = root_record.object_graph
     top_container_link_rlshp = SubContainer.find_relationship(:top_container_link)
     relationship_ids = tree_object_graph.ids_for(top_container_link_rlshp)
@@ -17,6 +20,7 @@ module ReindexTopContainers
   end
 
 
+  # not defined in accession or resource
   def update_position_only(*)
     super
     reindex_top_containers
@@ -32,7 +36,10 @@ module ReindexTopContainers
   def update_from_json(json, opts = {}, apply_nested_records = true)
     # we need to reindex top containers for instances about to be zapped
     # so remember the top containers we currently link to ...
-    top_container_ids = instance.map {|instance| instance.sub_container.first.related_records(:top_container_link).id }
+    top_container_ids = instance.map {|instance|
+                          # don't assume a sub_container - it might be a digital object instance
+                          instance.sub_container.map {|sc| sc.related_records(:top_container_link).id}
+                        }.flatten.compact
 
     result = super
 

--- a/backend/model/resource_ext.rb
+++ b/backend/model/resource_ext.rb
@@ -1,1 +1,2 @@
+Resource.include(ReindexTopContainers)
 Resource.include(RightsRestrictionNotes)

--- a/migrations/028_reindex_top_containers.rb
+++ b/migrations/028_reindex_top_containers.rb
@@ -1,0 +1,13 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    self[:top_container].update(:system_mtime => Time.now)
+    self[:container_profile].update(:system_mtime => Time.now)
+  end
+
+  down do
+  end
+
+end


### PR DESCRIPTION
and fix a bug where digital object instances weren't handled

[fixes #91108110]

This feels a little icky.